### PR TITLE
Hint at fixes for PySide recipe

### DIFF
--- a/pyside/build.sh
+++ b/pyside/build.sh
@@ -33,4 +33,8 @@ if [ `uname` == Darwin ]; then
     cp /usr/lib/libshiboken-python2.7.1.1.dylib $LIB
     cp /usr/lib/libpyside-python2.7.1.1.dylib $LIB
     cp -r /Library/Python/2.7/site-packages/PySide $SP
+    cp -r /Library/Python/2.7/site-packages/pysideuic $SP
+    cp /usr/bin/pyside-rcc $PREFIX/bin
+    cp /usr/bin/pyside-uic $PREFIX/bin
+    cp /usr/bin/pyside-lupdate $PREFIX/bin
 fi

--- a/pyside/run_test.py
+++ b/pyside/run_test.py
@@ -13,8 +13,17 @@ import PySide.QtUiTools
 import PySide.QtWebKit
 import PySide.QtXml
 import PySide.QtXmlPatterns
+import pysideuic
 
 import sys
 if sys.platform != 'linux2':
     import PySide.QtOpenGL
     import PySide.phonon
+
+from subprocess import check_call, CalledProcessError
+check_call(['pyside-uic', '--version'])
+check_call(['pyside-lupdate', '-version'])
+try:
+    check_call(['pyside-rcc', '-version'])
+except CalledProcessError as exc:
+    assert exc.returncode == 1


### PR DESCRIPTION
(This PR is just to discuss an issue with the PySide recipe; it shouldn't be accepted)

PySide includes 3 binary programs and a supplementary python module that aren't currently pulled into anaconda. They are

 * pyside-uic and the pysideuic module, which compile UI xml files into python
 * pyside-rcc, which compiles external resources (like icon files) into python modules
 * pyside-lupdate, which handles internationalization

I've hinted at how to pull these into anaconda on OSX, but I'm mostly guessing (I don't know how to recreate the conda build process)

cc @asmeurer