### PR TITLE
Fixed link to conda builder docs using the docs.continuum.io link, closes #6

### DIFF
--- a/appdirs/bld.bat
+++ b/appdirs/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/appdirs/build.sh
+++ b/appdirs/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/appdirs/meta.yaml
+++ b/appdirs/meta.yaml
@@ -51,5 +51,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/beautifulsoup4/bld.bat
+++ b/beautifulsoup4/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/beautifulsoup4/build.sh
+++ b/beautifulsoup4/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/beautifulsoup4/meta.yaml
+++ b/beautifulsoup4/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/binstar_client/bld.bat
+++ b/binstar_client/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/binstar_client/build.sh
+++ b/binstar_client/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/binstar_client/meta.yaml
+++ b/binstar_client/meta.yaml
@@ -65,5 +65,5 @@ about:
   license: BSD
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/blinker/bld.bat
+++ b/blinker/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/blinker/build.sh
+++ b/blinker/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/blinker/meta.yaml
+++ b/blinker/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/docopt/bld.bat
+++ b/docopt/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/docopt/build.sh
+++ b/docopt/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/ez_setup/bld.bat
+++ b/ez_setup/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/ez_setup/build.sh
+++ b/ez_setup/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/ez_setup/meta.yaml
+++ b/ez_setup/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: MIT
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/fabric-virtualenv/bld.bat
+++ b/fabric-virtualenv/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/fabric-virtualenv/build.sh
+++ b/fabric-virtualenv/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/fabric-virtualenv/meta.yaml
+++ b/fabric-virtualenv/meta.yaml
@@ -57,5 +57,5 @@ about:
   license: UNKNOWN
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/fabric/bld.bat
+++ b/fabric/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/fabric/build.sh
+++ b/fabric/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/fabric/meta.yaml
+++ b/fabric/meta.yaml
@@ -58,5 +58,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/fabtools/bld.bat
+++ b/fabtools/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/fabtools/build.sh
+++ b/fabtools/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/fabtools/meta.yaml
+++ b/fabtools/meta.yaml
@@ -59,5 +59,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/feedgenerator/bld.bat
+++ b/feedgenerator/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/feedgenerator/build.sh
+++ b/feedgenerator/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/feedgenerator/meta.yaml
+++ b/feedgenerator/meta.yaml
@@ -59,5 +59,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/graphterm/bld.bat
+++ b/graphterm/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/graphterm/build.sh
+++ b/graphterm/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/graphterm/meta.yaml
+++ b/graphterm/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/html2text/bld.bat
+++ b/html2text/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/html2text/build.sh
+++ b/html2text/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/html2text/meta.yaml
+++ b/html2text/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: GNU General Public License (GPL)
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/html5lib/bld.bat
+++ b/html5lib/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/html5lib/build.sh
+++ b/html5lib/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/html5lib/meta.yaml
+++ b/html5lib/meta.yaml
@@ -56,5 +56,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/iep/bld.bat
+++ b/iep/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/iep/build.sh
+++ b/iep/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/iep/meta.yaml
+++ b/iep/meta.yaml
@@ -57,5 +57,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/importlib/bld.bat
+++ b/importlib/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/importlib/build.sh
+++ b/importlib/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/importlib/meta.yaml
+++ b/importlib/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: Python Software Foundation License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/joblib/bld.bat
+++ b/joblib/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/joblib/build.sh
+++ b/joblib/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/joblib/meta.yaml
+++ b/joblib/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/keyring/bld.bat
+++ b/keyring/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/keyring/build.sh
+++ b/keyring/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/keyring/meta.yaml
+++ b/keyring/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: PSF
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/livereload/bld.bat
+++ b/livereload/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/livereload/build.sh
+++ b/livereload/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/milk/bld.bat
+++ b/milk/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/milk/build.sh
+++ b/milk/build.sh
@@ -6,5 +6,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/milk/meta.yaml
+++ b/milk/meta.yaml
@@ -54,5 +54,5 @@ about:
   license: MIT
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/paramiko/bld.bat
+++ b/paramiko/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/paramiko/build.sh
+++ b/paramiko/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/paramiko/meta.yaml
+++ b/paramiko/meta.yaml
@@ -56,5 +56,5 @@ about:
   license: GNU Library or Lesser General Public License (LGPL)
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/pelican/bld.bat
+++ b/pelican/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/pelican/build.sh
+++ b/pelican/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/pelican/meta.yaml
+++ b/pelican/meta.yaml
@@ -80,5 +80,5 @@ about:
   license: GNU Affero General Public License v3
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/pudb/bld.bat
+++ b/pudb/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/pudb/build.sh
+++ b/pudb/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/pyflakes/bld.bat
+++ b/pyflakes/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/pyflakes/build.sh
+++ b/pyflakes/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/pyflakes/meta.yaml
+++ b/pyflakes/meta.yaml
@@ -56,5 +56,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/pytz/bld.bat
+++ b/pytz/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/pytz/build.sh
+++ b/pytz/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/pytz/meta.yaml
+++ b/pytz/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: MIT License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/pyzolib/bld.bat
+++ b/pyzolib/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/pyzolib/build.sh
+++ b/pyzolib/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/pyzolib/meta.yaml
+++ b/pyzolib/meta.yaml
@@ -46,5 +46,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/requests/bld.bat
+++ b/requests/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/requests/build.sh
+++ b/requests/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/requests/meta.yaml
+++ b/requests/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: ache Software License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/rq/bld.bat
+++ b/rq/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/rq/build.sh
+++ b/rq/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/rq/meta.yaml
+++ b/rq/meta.yaml
@@ -66,5 +66,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/snakeviz/bld.bat
+++ b/snakeviz/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/snakeviz/build.sh
+++ b/snakeviz/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/snakeviz/meta.yaml
+++ b/snakeviz/meta.yaml
@@ -58,5 +58,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/times/bld.bat
+++ b/times/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/times/build.sh
+++ b/times/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/times/meta.yaml
+++ b/times/meta.yaml
@@ -59,5 +59,5 @@ about:
   license: BSD License
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/toolshed/bld.bat
+++ b/toolshed/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/toolshed/build.sh
+++ b/toolshed/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/unidecode/bld.bat
+++ b/unidecode/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/unidecode/build.sh
+++ b/unidecode/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/unidecode/meta.yaml
+++ b/unidecode/meta.yaml
@@ -55,5 +55,5 @@ about:
   license: GNU General Public License v2 or later (GPLv2+)
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/urwid/bld.bat
+++ b/urwid/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/urwid/build.sh
+++ b/urwid/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install || exit 1
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/veusz/bld.bat
+++ b/veusz/bld.bat
@@ -5,5 +5,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.

--- a/veusz/build.sh
+++ b/veusz/build.sh
@@ -5,5 +5,5 @@ $PYTHON setup.py install
 # Add more build steps here, if they are necessary.
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+# http://docs.continuum.io/conda/build.html
 # for a list of environment variables that are set during the build process.

--- a/viper/meta.yaml
+++ b/viper/meta.yaml
@@ -34,5 +34,5 @@ about:
   license: TBD
 
 # See
-# https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt for
+# http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml

--- a/yt/bld.bat
+++ b/yt/bld.bat
@@ -4,5 +4,5 @@ if errorlevel 1 exit 1
 :: Add more build steps here, if they are necessary.
 
 :: See
-:: https://github.com/ContinuumIO/conda/blob/master/conda/builder/README.txt
+:: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.


### PR DESCRIPTION
Use the docs.continuum.io link.

To avoid the useless intermediate commit I submit a new pull request based on current master. Hope it works now! :)
