### PR TITLE
Add license info for Superlance

### DIFF
--- a/superlance/meta.yaml
+++ b/superlance/meta.yaml
@@ -64,7 +64,7 @@ test:
 
 about:
   home: http://supervisord.org
-  license: UNKNOWN
+  license: BSD-derived (http://www.repoze.org/LICENSE.txt)
 
 # See
 # http://docs.continuum.io/conda/build.html for

--- a/supervisor/meta.yaml
+++ b/supervisor/meta.yaml
@@ -62,7 +62,7 @@ test:
 
 about:
   home: http://supervisord.org/
-  license: BSD
+  license: BSD-derived (http://www.repoze.org/LICENSE.txt)
 
 # See
 # http://docs.continuum.io/conda/build.html for


### PR DESCRIPTION
A license file was added in https://github.com/Supervisor/superlance/commit/ee368eec4a37369e83b5dec29c47630a3eec72d0.  
