### PR TITLE
Updating yt recipe for yt 2.5.5

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 2.5.3
+  version: 2.5.5
 
 source:
-  fn: yt-2.5.3.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-2.5.3.tar.gz
-  md5: 21f5ba35f4aee659c5be901a16b916bd
+  fn: yt-2.5.5.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-2.5.5.tar.gz
+  md5: 1b497061d1b7ee0859caec1c8a1ef2e2
 
 build:
   entry_points:
@@ -19,6 +19,7 @@ requirements:
     - libpng
     - freetype
     - hdf5
+    - distribute
   run:
     - python
     - numpy
@@ -37,4 +38,4 @@ test:
 
 about:
   home: http://yt-project.org/
-  license: GNU General Public License version 2 (GPL)
+  license: GNU General Public License version 3 (GPL)


### PR DESCRIPTION
This updates the yt recipe to build the newest released version.

I've also corrected the license tag. 
