### PR TITLE
Updating the hdf5 url and OSX build number.

### DIFF
--- a/hdf5/meta.yaml
+++ b/hdf5/meta.yaml
@@ -4,11 +4,11 @@ package:
 
 source:
   fn: hdf5-1.8.9.tar.bz2
-  url: http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.9.tar.bz2
+  url: http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.9/src/hdf5-1.8.9.tar.bz2
   md5: 33e105583417eff1c57fff910a53cd6f
 
 build:
-  number: 1            [osx]
+  number: 2            [osx]
 
 about:
   home: http://www.hdfgroup.org/HDF5/


### PR DESCRIPTION
This updates the URL for hdf5.  So lond as the HDF group doesn't change their site too much in the future, this URL pattern should be permanent for this release and all future releases - including the current release.

I've also updated the build number for OS X.
