### PR TITLE
working fix to build pymc with numpy-1.7 on a win32 environment

### DIFF
--- a/pymc/bld.bat
+++ b/pymc/bld.bat
@@ -1,13 +1,9 @@
-%PYTHON% setup.py install
+%SYS_PYTHON% setup.py build --compiler=mingw32 
+%SYS_PYTHON% setup.py install --prefix=%PREFIX%
 if errorlevel 1 exit 1
 
-if "%ARCH%"=="32" (
-   set MINGW_NAME=i686-w64-mingw32
-) else (
-   set MINGW_NAME=x86_64-w64-mingw32
-)
 
 for %%x in (libgcc_s_sjlj-1.dll libgfortran-3.dll libquadmath-0.dll) do (
-   copy %PREFIX%\MinGW\%MINGW_NAME%\lib\%%x %SP_DIR%\pymc\
+   copy %SYS_PREFIX%\Scripts\%%x %SP_DIR%\pymc\
    if errorlevel 1 exit 1
 )


### PR DESCRIPTION
It is maybe not the smartest way, but it helps building the module for anaconda 1.7 on win-32.

I followed @twiecki suggestion and made that PR  (https://groups.google.com/a/continuum.io/forum/#!msg/anaconda/E3lUTyavS7Y/2bTwdIhHdk8J)

related issues:
- ContinuumIO/anaconda-issues#7
- ContinuumIO/conda-recipes/pull/16
