### PR TITLE
Fixed pymc md5 issue

### DIFF
--- a/pymc/meta.yaml
+++ b/pymc/meta.yaml
@@ -4,8 +4,8 @@ package:
 
 source:
   fn:  pymc-2.3.tar.gz
-  url: https://github.com/pymc-devs/pymc/archive/2.3.tar.gz
-  md5: 3b644a6e11cd2a57c6fcd3ee593d8d9e
+  url: https://pypi.python.org/packages/source/p/pymc/pymc-2.3.tar.gz
+  md5: 03678068b552eecb16fc7aded39d125a
 
 requirements:
   build:


### PR DESCRIPTION
The PyMC recipe should work in this commit. I was not able to resolve the MD5 issue using a GitHub tarball, for some reason, but it works fine if I use PyPI.
