### PR TITLE
Updating yt recipe for yt-2.6

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 2.5.5
+  version: 2.6
 
 source:
-  fn: yt-2.5.5.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-2.5.5.tar.gz
-  md5: 1b497061d1b7ee0859caec1c8a1ef2e2
+  fn: yt-2.6.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-2.6.tar.gz
+  md5: 3fb120071f7fe59211ee1edfa14dd2f2
 
 build:
   entry_points:
@@ -25,7 +25,6 @@ requirements:
     - numpy
     - libpng
     - freetype
-    - hdf5
     - h5py
     - matplotlib
 
@@ -38,4 +37,4 @@ test:
 
 about:
   home: http://yt-project.org/
-  license: GNU General Public License version 3 (GPL)
+  license: BSD 3-Clause License


### PR DESCRIPTION
This updates the yt recipe for yt-2.6.

This is the first release of yt with a BSD license.  Is there some way we can request that yt be included with anaconda or be made available via the official Continuum conda package streams?
