### PR TITLE
Update python-coveralls to 2.4.1

### DIFF
--- a/python-coveralls/meta.yaml
+++ b/python-coveralls/meta.yaml
@@ -1,15 +1,14 @@
 package:
   name: python-coveralls
-  version: 2.4.0
+  version: 2.4.1
 
 source:
-  fn: python-coveralls-2.4.0.tar.gz
-  url: https://pypi.python.org/packages/source/p/python-coveralls/python-coveralls-2.4.0.tar.gz
-  md5: 8e9dfc1ef9059719535bd1bb9d235552
+  fn: python-coveralls-2.4.1.tar.gz
+  url: https://pypi.python.org/packages/source/p/python-coveralls/python-coveralls-2.4.1.tar.gz
+  md5: 36e6a21be9dceedd09d50f48dd80b87b
 
   patches:
    # List any patch files here
-   - patchfile
 
 build:
   entry_points:

--- a/python-coveralls/patchfile
+++ b/python-coveralls/patchfile
@@ -1,9 +1,0 @@
-diff --git requirements.txt requirements.txt
-index 9b2726a..408d257 100644
---- requirements.txt
-+++ requirements.txt
-@@ -1,4 +1,3 @@
--argparse
- PyYAML
- requests
- coverage


### PR DESCRIPTION
python-coveralls has been updated to 2.4.1, which removes the need for a patch I had that worked around incorrect requirements in Python 2.7 and 3.3.
