### PR TITLE
Update DRMAA to 0.7.1

### DIFF
--- a/drmaa/meta.yaml
+++ b/drmaa/meta.yaml
@@ -27,7 +27,7 @@ source:
 requirements:
   build:
     - python
-    - setuptools
+    - distribute
 
   run:
     - python


### PR DESCRIPTION
Library is now officially Python 3 compatible.
