### PR TITLE
Update chardet to 2.2.1

### DIFF
--- a/chardet/meta.yaml
+++ b/chardet/meta.yaml
@@ -25,8 +25,8 @@ test:
   imports:
     - chardet
 
-#  commands:
-#    - chardetect --help
+  commands:
+    - chardetect run_test.py
 
 about:
   home: https://github.com/chardet/chardet


### PR DESCRIPTION
I've recently gotten involved in development for `chardet`, and so we just made the first release in a few years. It's now 2/3 compatible after a merger with `charade`, which was formerly used by `requests`.
