### PR TITLE
h5py: add python as a build dependency

### DIFF
--- a/h5py/meta.yaml
+++ b/h5py/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 requirements:
   build:
+    - python
     - numpy
     - hdf5
   run:


### PR DESCRIPTION
This seems to be required to build under Python 3.
