### PR TITLE
Add recipe for faulthandler on 2.6 and 2.7.

### DIFF
--- a/faulthandler/bld.bat
+++ b/faulthandler/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/faulthandler/build.sh
+++ b/faulthandler/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/faulthandler/meta.yaml
+++ b/faulthandler/meta.yaml
@@ -1,0 +1,57 @@
+package:
+  name: faulthandler
+  version: 2.3
+
+source:
+  fn: faulthandler-2.3.tar.gz
+  url: https://pypi.python.org/packages/source/f/faulthandler/faulthandler-2.3.tar.gz
+  md5: 76d1344adc2302cf5c59a5f8a4f4f4ae
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - faulthandler = faulthandler:main
+    #
+    # Would create an entry point called faulthandler that calls faulthandler.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - faulthandler
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/haypo/faulthandler/wiki/
+  license: BSD License
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
It's included with 3.3, so no need to build a package there.
