### PR TITLE
Revert to previous md5 as on PyPI

### DIFF
--- a/pymc/meta.yaml
+++ b/pymc/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
   fn:  pymc-2.3.tar.gz
   url: https://pypi.python.org/packages/source/p/pymc/pymc-2.3.tar.gz
-  md5: 3b644a6e11cd2a57c6fcd3ee593d8d9e
+  md5: 03678068b552eecb16fc7aded39d125a
 
 requirements:
   build:


### PR DESCRIPTION
The md5 checksum of the file on PyPI seems to now have the previous value in commit 1bc08df95e and not the value added in commit 071776f6ce.

Trying to use `conda build pymc` currently gives this error:
Error: MD5 mismatch: '03678068b552eecb16fc7aded39d125a' != '3b644a6e11cd2a57c6fcd3ee593d8d9e'
