### PR TITLE
Add windows build recipe for pyopt

### DIFF
--- a/pyOpt/add_pyOpt_to_path_while_importing.patch
+++ b/pyOpt/add_pyOpt_to_path_while_importing.patch
@@ -1,0 +1,20 @@
+diff --git pyOpt/__init__.py pyOpt/__init__.py
+index 7177ca8..a4c02f9 100644
+--- pyOpt/__init__.py
++++ pyOpt/__init__.py
+@@ -14,6 +14,8 @@ from pyOpt_optimizer import Optimizer
+ __all__ = ['History','Parameter','Variable','Gradient','Constraint','Objective','Optimization','Optimizer']
+ 
+ dir = os.path.dirname(os.path.realpath(__file__))
++if sys.platform == 'win32':
++    os.environ["PATH"] = os.environ["PATH"] + os.pathsep + dir
+ for f in os.listdir(dir):
+     if f.startswith('py') and os.path.isdir(os.path.join(dir,f)):
+         try:
+@@ -24,3 +26,5 @@ for f in os.listdir(dir):
+         #end
+     #end
+ #end
++if sys.platform == 'win32':
++    os.environ["PATH"] = os.environ["PATH"].replace(os.pathsep + dir, '')
+\ No newline at end of file

--- a/pyOpt/bld.bat
+++ b/pyOpt/bld.bat
@@ -1,0 +1,20 @@
+swig.exe 2> NUL
+if %ERRORLEVEL%==9009 GOTO Swig_missing
+
+REM Copy any licenced source files the optimizers
+REM SET SNOPT_DIR="z:\snopt7"
+REM IF EXIST %SNOPT_DIR% ( xcopy %SNOPT_DIR%\src\* "%SRC_DIR%"\pyOpt\pySNOPT\source\* /S/Y/I/Q )
+
+%SYS_PYTHON% setup.py install --compiler=mingw32 --prefix=%PREFIX%
+
+for %%x in (libgfortran-3.dll libquadmath-0.dll) do (
+   copy %SYS_PREFIX%\Scripts\%%x %SP_DIR%\pyopt\
+   if errorlevel 1 exit 1
+)
+
+GOTO End
+
+:Swig_missing
+Echo "Swig.exe is missing in PATH"
+
+:End

--- a/pyOpt/meta.yaml
+++ b/pyOpt/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: pyopt     # lower case name of package, may contain '-' but no spaces
+  version: 1.1.0    # version of package. Should use the PEP-386 verlib conventions.
+
+source:
+# The source section specifies where the source code of the package is coming
+# from, it may be coming from a source tarball like:
+  fn: pyOpt-1.1.0.tar.gz
+  url: http://www.pyopt.org/_downloads/pyOpt-1.1.0.tar.gz
+
+
+  
+# The build number should be incremented for new builds of the same version
+build:            # (optional)
+  number: 0                        # (optional, defaults to 0)
+
+  
+# the build and runtime requirements:
+requirements:     # (optional)
+  build:
+    - python 
+    - numpy
+  run:
+    - python
+    - numpy
+
+about:            # (optional)
+  home: http://www.pyopt.org/index.html


### PR DESCRIPTION
Windows build recipe for pyopt (pyopt.org). Tested on win64.