### PR TITLE
Update Psycopg to 2.5.2

### DIFF
--- a/psycopg2/meta.yaml
+++ b/psycopg2/meta.yaml
@@ -1,28 +1,11 @@
 package:
   name: psycopg2
-  version: 2.5.1
+  version: 2.5.2
 
 source:
-  fn: psycopg2-2.5.1.tar.gz
-  url: https://pypi.python.org/packages/source/p/psycopg2/psycopg2-2.5.1.tar.gz
-  md5: 1b433f83d50d1bc61e09026e906d84c7
-#  patches:
-   # List any patch files here
-   # - fix.patch
-
-# build:
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - psycopg2 = psycopg2:main
-    #
-    # Would create an entry point called psycopg2 that calls psycopg2.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  fn: psycopg2-2.5.2.tar.gz
+  url: https://pypi.python.org/packages/source/p/psycopg2/psycopg2-2.5.2.tar.gz
+  md5: 53d81793fbab8fee6e732a0425d50047
 
 requirements:
   build:
@@ -37,22 +20,7 @@ test:
     - psycopg2
     - psycopg2.tests
 
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
-
 about:
   home: http://initd.org/psycopg/
   license: GNU Library or Lesser General Public License (LGPL) or Zope Public License
 
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml


### PR DESCRIPTION
Will prevent future people from getting bit by the segfault in 2.5.1: http://initd.org/psycopg/articles/2014/01/07/psycopg-252-released/