### PR TITLE
Add cpanminus to Perl recipe

### DIFF
--- a/perl/build.sh
+++ b/perl/build.sh
@@ -3,9 +3,6 @@
 # Build perl
 sh Configure -de -Dprefix=$PREFIX -Duserelocatableinc
 make
+# The next part is commented out because some tests are unreliable on OS X
 # make test
 make install
-
-# Install CPAN Minus to make building other packages that rely on this simpler
-echo "Installing CPAN Minus"
-curl -L http://cpanmin.us | perl - App::cpanminus

--- a/perl/meta.yaml
+++ b/perl/meta.yaml
@@ -2,12 +2,8 @@ package:
   name: perl
   version: 5.18.2
 
-requirements:
-  build:
-    - curl
-
 build:
-  number: 5
+  number: 8
 
 source:
   fn: perl-5.18.2.tar.gz
@@ -17,7 +13,6 @@ source:
 test:
   commands:
     - perl --help
-    - cpanm --help
 
 about:
   home: http://www.perl.org/


### PR DESCRIPTION
To make it simpler for me to create a CPAN skeleton, I needed to include cpanminus to the base Perl package. You'll see a pull request from me adding the CPAN skeleton to conda-build very soon, but it relies on this version of the Perl recipe.
