### PR TITLE
Fix patchelf version typo

### DIFF
--- a/patchelf/meta.yaml
+++ b/patchelf/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: patchelf
-  version: 0.15
+  version: 0.6
 
 source:
   git_url: https://github.com/NixOS/patchelf.git


### PR DESCRIPTION
It listed 0.15 as the package version, but 0.6 is the version this recipe is for.
