### PR TITLE
Linux is the only supported platform.  Fail faster on other platforms

### DIFF
--- a/wxpython/meta.yaml
+++ b/wxpython/meta.yaml
@@ -4,9 +4,9 @@ package:
     version: 3.0.0.0
 
 source:
-    fn: wxPython-src-3.0.0.0.tar.bz2
-    url: http://downloads.sourceforge.net/wxpython/wxPython-src-3.0.0.0.tar.bz2
-    sha1: 48451763275cfe4e5bbec49ccd75bc9652cba719
+    fn: wxPython-src-3.0.0.0.tar.bz2  # [linux]
+    url: http://downloads.sourceforge.net/wxpython/wxPython-src-3.0.0.0.tar.bz2 # [linux]
+    sha1: 48451763275cfe4e5bbec49ccd75bc9652cba719 # [linux]
 
 build:
     number: 2


### PR DESCRIPTION
@asmeurer Just an update to wxpython to make it fail faster on unsupported platforms.  It looks like the build.sh only supports linux, so i put selectors around the URL.  
