### PR TITLE
Feature/vim

### DIFF
--- a/vim/build.sh
+++ b/vim/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX \
+            --enable-rubyinterp \
+            --enable-pythoninterp \
+            --with-features=huge
+
+make VIMRUNTIMEDIR=AAAAA
+make install

--- a/vim/meta.yaml
+++ b/vim/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: vim
+  version: 7.4
+
+source: 
+  hg_url: https://code.google.com/p/vim/
+
+requirements:
+
+  build:
+    - cmake
+
+test:
+  commands:
+    - vim --help
+    - vim --version
+    - vim --version | grep 7.4
+
+
+about:
+  home: https://vim.googlecode.com/
+  license: BSD
+

--- a/vim/post-link.sh
+++ b/vim/post-link.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cd $PREFIX/bin
+
+cat <<EOF > set_vim_path.sh
+x=$PATH
+env=${x%%:*}
+bad_path="bin/"
+share="share/vim/vim74/"
+new_env=${env/bin/$share}
+export VIMRUNTIME=$new_env
+EOF
+
+chmod +x ./set_vim_path.sh
+


### PR DESCRIPTION
VIM is a little weird in that a relocatable package seems impossible.  During the build process you can set a **VIMRUNTIME** path but this obviously won't work for multiple envs.  My solutions builds VIM and a bash file: `set_vim_path.sh` which, after being executed, sets the **VIMRUNTIME** path appropriately after inspecting the current envs PATH.
