### PR TITLE
added emacs packages

### DIFF
--- a/emacs/build.sh
+++ b/emacs/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+./configure  --without-gsettings --prefix=$PREFIX
+
+make -j4  && make -j4  install
+cp $RECIPE_DIR/start_emacs.sh $PREFIX/bin

--- a/emacs/meta.yaml
+++ b/emacs/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: emacs 
+  version: 24.3 
+
+source:
+  fn: emacs-24.3.tar.gz
+  url: http://ftp.gnu.org/gnu/emacs/emacs-24.3.tar.gz
+  md5: d20441025efd4931ef64cc2bb18eddc9 
+
+test:
+  commands:
+    - emacs --help
+
+about:
+  home: http://www.cmake.org/
+  license: BSD

--- a/emacs/start_emacs.sh
+++ b/emacs/start_emacs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+
+export LISPBOX_HOME=~/anaconda/envs/$CONDA_DEFAULT_ENV
+
+
+export EMACSDATA=${LISPBOX_HOME}/share/emacs/24.3/etc/
+
+export EMACSLOADPATH=\
+${LISPBOX_HOME}/share/emacs/24.3/site-lisp:\
+${LISPBOX_HOME}/share/emacs/site-lisp:\
+${LISPBOX_HOME}/share/emacs/24.3/leim:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/toolbar:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/textmodes:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/progmodes:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/play:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/obsolete:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/net:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/mail:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/language:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/international:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/gnus:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/eshell:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/emulation:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/emacs-lisp:\
+${LISPBOX_HOME}/share/emacs/24.3/lisp/calendar
+
+emacs

--- a/emacs_libs/build.sh
+++ b/emacs_libs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#ls /usr/lib64/ | grep gtk | xargs -i{} cp -r  /usr/lib64/{} $PREFIX/lib
+echo $PREFIX
+ls $PREFIX
+mkdir $PREFIX/lib
+cp -r  /usr/lib64/* $PREFIX/lib/
+#find /usr/lib64/ -maxdepth 1 -type f | xargs -i{} cp -r {} $PREFIX/lib
+ls $PREFIX/lib
+

--- a/emacs_libs/meta.yaml
+++ b/emacs_libs/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: emacs_libs 
+  version: 24.3 
+
+
+
+build:
+  binary_relocation: false
+about:
+  home: http://www.cmake.org/
+  license: BSD


### PR DESCRIPTION
This needs some cleanup, but with this package I can install emacs 24.3 on any machine with:

```
conda install --force -c https://conda.binstar.org/paddy emacs emacs_libs &&  source ~/anaconda/envs/paddy_emacs2/bin/start_emacs.sh
```

where `paddy_emacs2` is the name of my anaconda environment
