### PR TITLE
Update Spyder recipe

### DIFF
--- a/spyder/meta.yaml
+++ b/spyder/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: spyder
-  version: 2.3.0beta3
+  version: 2.3.0rc
 
 source:
-  fn: spyder-2.3.0beta3.zip
-  url: https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-2.3.0beta3.zip
-  sha1: 5694c2759ae175b4fd65f9713ac1a5dff21f1fa2
+  fn: spyder-2.3.0rc.zip
+  url: https://bitbucket.org/spyder-ide/spyderlib/downloads/spyder-2.3.0rc.zip
+  sha1: 0a487cf49efc06cb6a2e9532153f901772969870
 
 build:
   osx_is_app: True
@@ -14,15 +14,18 @@ requirements:
   build:
     - python
     - sphinx
-    - rope
-    - pyflakes
   run:
     - python
-    - ipython
-    - pygments
     - pyzmq
-    - pyside-pyzo          [not linux]
-    - pyqt            [linux]
+    - ipython
+    - rope
+    - pyflakes
+    - pygments
+    - jinja2
+    - sphinx
+    - pep8
+    - pylint
+    - pyqt
     - python.app      [osx]
 
 test:


### PR DESCRIPTION
- Bump version to 2.3.0rc
- Rope and pyflakes are not build dependencies but run ones.
- Add jinja2, sphinx, pep8 and pylint as run dependencies too to cover
  Object Inspector dependencies along with more functionality for the
  Editor.
- Make pyqt a run dependency for all OSes (as I understand that's the
  case now).
