### PR TITLE
Don't remove Qt plugins on Linux

### DIFF
--- a/qt/build.sh
+++ b/qt/build.sh
@@ -12,7 +12,7 @@ if [ `uname` == Linux ]; then
 
     cp $SRC_DIR/bin/* $PREFIX/bin/
     cd $PREFIX
-    rm -rf doc imports mkspecs phrasebooks plugins q3porting.xml translations
+    rm -rf doc imports mkspecs phrasebooks q3porting.xml translations
     rm -rf demos examples tests
     cd $PREFIX/bin
     rm -f *.bat *.pl qt3to4 qdoc3


### PR DESCRIPTION
- Without them Qt can't show gif, jpeg, svg and tiff files.
- Without this support Spyder can't show its icon on the KDE taskbar,
  nor a simple throbber (animated gif) while opening an IPython console.
