### PR TITLE
Update HDF5 to 1.8.13 and provide static library.

### DIFF
--- a/hdf5/build.sh
+++ b/hdf5/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-./configure --prefix=$PREFIX --disable-static \
-    --enable-linux-lfs --with-zlib --with-ssl
+./configure --prefix=$PREFIX --enable-linux-lfs --with-zlib --with-ssl
 make
 make install
 

--- a/hdf5/meta.yaml
+++ b/hdf5/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: hdf5
-  version: 1.8.9
+  version: 1.8.13
 
 source:
-  fn: hdf5-1.8.9.tar.bz2
-  url: http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.9/src/hdf5-1.8.9.tar.bz2
-  md5: 33e105583417eff1c57fff910a53cd6f
+  fn: hdf5-1.8.13.tar.bz2
+  url: http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.bz2
+  md5: b060bb137d6bd8accf8f0c4c59d2746d
 
 build:
-  number: 2            [osx]
+  number: 0
 
 about:
   home: http://www.hdfgroup.org/HDF5/


### PR DESCRIPTION
The CDAT-lite package requires the static library to be installed.
