### PR TITLE
Add recipe for vpython and its dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ In more detail, assuming you have anaconda installed and you have downloaded thi
 conda update conda  # a good habit, always
 conda install conda-build  # unless you already have it, of course
 cd conda-vpython-recipes  # or whathever you called it 
-conda build boost # boost needs to be built before vpython
+conda build boost-vpython # boost needs to be built before vpython
 conda build fonttools polygon2 ttfquery vpython
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+conda-vpython-recipes
+=====================
+
+Use these recipes to build [vpython](http://vpython.org) for the
+[anaconda python distribution](https://store.continuum.io/cshop/anaconda/).
+
+In more detail, assuming you have anaconda installed and you have downloaded this repo:
+
+```bash
+conda update conda  # a good habit, always
+conda install conda-build  # unless you already have it, of course
+cd conda-vpython-recipes  # or whathever you called it 
+conda build boost # boost needs to be built before vpython
+conda build fonttools polygon2 ttfquery vpython
+```

--- a/boost-vpython/bld.bat
+++ b/boost-vpython/bld.bat
@@ -1,0 +1,2 @@
+python setup.py install
+if errorlevel 1 exit 1

--- a/boost-vpython/bld.bat
+++ b/boost-vpython/bld.bat
@@ -1,2 +1,2 @@
-cmd /c bootstrap msvc
-b2 --prefix=%PREFIX% --build-type=complete --with-python --with-signals  --toolset=msvc install
+cmd /c bootstrap
+b2 address-model=%ARCH% --prefix=%PREFIX% --build-type=complete --with-python --with-signals  --toolset=msvc install

--- a/boost-vpython/bld.bat
+++ b/boost-vpython/bld.bat
@@ -1,2 +1,7 @@
+REM It seems like bootstrap is easily confused -- without the line below it complains
+REM that it cannot find VCVARS32.bat when building 64bit on 64bit, which it shouldn't even need.
+if %ARCH% == 64 (
+	call "\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsx86_amd64.bat"
+)
 cmd /c bootstrap
 b2 address-model=%ARCH% --prefix=%PREFIX% --build-type=complete --with-python --with-signals  --toolset=msvc install

--- a/boost-vpython/bld.bat
+++ b/boost-vpython/bld.bat
@@ -1,2 +1,2 @@
-python setup.py install
-if errorlevel 1 exit 1
+cmd /c bootstrap msvc
+b2 --prefix=%PREFIX% --build-type=complete --with-python --with-signals  --toolset=msvc install

--- a/boost-vpython/build.sh
+++ b/boost-vpython/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Hints:
+# http://boost.2283326.n4.nabble.com/how-to-build-boost-with-bzip2-in-non-standard-location-td2661155.html
+# http://www.gentoo.org/proj/en/base/amd64/howtos/?part=1&chap=3
+
+# Build dependencies:
+# - bzip2-devel
+
+export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC -shared"
+export CXXFLAGS="${CFLAGS}"
+
+mkdir -vp ${PREFIX}/bin;
+
+./bootstrap.sh --prefix="${PREFIX}/";
+./b2 --with-python --with-signals install;
+
+#POST_LINK="${PREFIX}/bin/.boost-post-link.sh"
+#cp -v ${RECIPE_DIR}/post-link.sh ${POST_LINK};
+#chmod -v 0755 ${POST_LINK};

--- a/boost-vpython/meta.yaml
+++ b/boost-vpython/meta.yaml
@@ -1,0 +1,24 @@
+
+package:
+    name: boost-vpython
+    version: 1.55.0
+
+source:
+    fn: boost_1_55_0.tar.bz2
+    url: http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
+
+build:
+    number: 0
+
+requirements:
+    build:
+
+    run:
+
+test:
+    imports:
+
+about:
+    home: http://www.boost.org/
+    license: Boost-1.0
+

--- a/boost-vpython/post-link.sh
+++ b/boost-vpython/post-link.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat <<EOF >> ${PREFIX}/.messages.txt
+This is an install message from the boost package.
+EOF

--- a/fonttools/bld.bat
+++ b/fonttools/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/fonttools/build.sh
+++ b/fonttools/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/fonttools/meta.yaml
+++ b/fonttools/meta.yaml
@@ -1,0 +1,67 @@
+package:
+  name: fonttools
+  version: !!str 2.4
+
+source:
+  fn: FontTools-2.4.tar.gz
+  url: https://pypi.python.org/packages/source/F/FontTools/FontTools-2.4.tar.gz
+  md5: 304b20e6109787c0ff4467d2b9f7f2c5
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - fonttools = fonttools:main
+    #
+    # Would create an entry point called fonttools that calls fonttools.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - fontTools
+    - fontTools.encodings
+    - fontTools.misc
+    - fontTools.pens
+    - fontTools.ttLib
+    - fontTools.ttLib.tables
+    - fontTools.ttLib.test
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://fonttools.sourceforge.net/
+  license: BSD License
+  summary: 'Tools to manipulate font files'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/polygon2/bld.bat
+++ b/polygon2/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/polygon2/build.sh
+++ b/polygon2/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/polygon2/meta.yaml
+++ b/polygon2/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: polygon2
+  version: !!str 2.0.6
+
+source:
+  fn: Polygon2-2.0.6.zip
+  url: https://bitbucket.org/jraedler/polygon2/downloads/Polygon2-2.0.6.zip
+  md5: a35b44a14ff54c53aceea5bb06b1c3ef
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ttfquery = ttfquery:main
+    #
+    # Would create an entry point called ttfquery that calls ttfquery.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - Polygon
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://www.j-raedler.de/projects/polygon/
+  license: LGPL License
+  summary: 'Handles polygonal shapes in 2D and includes python bindings for gpc'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/ttfquery/bld.bat
+++ b/ttfquery/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/ttfquery/build.sh
+++ b/ttfquery/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/ttfquery/meta.yaml
+++ b/ttfquery/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: ttfquery
+  version: !!str 1.0.5
+
+source:
+  fn: TTFQuery-1.0.5.tar.gz
+  url: https://pypi.python.org/packages/source/T/TTFQuery/TTFQuery-1.0.5.tar.gz
+  md5: 6e01d38684eb94978fad70eba4c68463
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ttfquery = ttfquery:main
+    #
+    # Would create an entry point called ttfquery that calls ttfquery.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - ttfquery
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://ttfquery.sourceforge.net/
+  license: BSD License
+  summary: 'FontTools-based package for querying system fonts'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/vpython/bld.bat
+++ b/vpython/bld.bat
@@ -1,12 +1,12 @@
 REM Set up environment for building with MSVC
 
-call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
+REM call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
 
 set INCLUDE="%PREFIX%\include\boost-1_55";"%PREFIX%"\include;"%PREFIX%\lib\site-packages\numpy\core\include";%INCLUDE%
 set LIB="%PREFIX%\libs";"%PREFIX%\lib";%LIB%
 
 cd %SRC_DIR%
-msbuild VCBuild\cvisual27-32bit.vcproj /property:Configuration=Release /property:Platform=Win32 /p:"VCBuildAdditionalOptions=/useenv"
+msbuild VCBuild\cvisual27.vcproj /property:Configuration=Release /property:Platform=x64 /p:"VCBuildAdditionalOptions=/useenv"
 if errorlevel 1 exit 1
 
 xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\visual  "%PREFIX%"\lib\site-packages\visual

--- a/vpython/bld.bat
+++ b/vpython/bld.bat
@@ -1,0 +1,16 @@
+REM Set up environment for building with MSVC
+
+call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
+
+set INCLUDE="%PREFIX%\include\boost-1_55";"%PREFIX%"\include;"%PREFIX%\lib\site-packages\numpy\core\include";%INCLUDE%
+set LIB="%PREFIX%\libs";"%PREFIX%\lib";%LIB%
+
+cd %SRC_DIR%
+msbuild VCBuild\cvisual27-32bit.vcproj /property:Configuration=Release /property:Platform=Win32 /p:"VCBuildAdditionalOptions=/useenv"
+if errorlevel 1 exit 1
+
+xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\visual  "%PREFIX%"\lib\site-packages\visual
+xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\vis  "%PREFIX%"\lib\site-packages\vis
+xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\visual_common  "%PREFIX%"\lib\site-packages\visual_common
+xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\vidle2  "%PREFIX%"\lib\site-packages\vidle
+

--- a/vpython/bld.bat
+++ b/vpython/bld.bat
@@ -1,11 +1,11 @@
 REM Set up environment for building with MSVC
 
-if %ARCH% == "32" (
+if %ARCH% == 32 (
     call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
-    set PROJECT_FILE="cvisual27-32bit.vcproj"
+    set PROJECT_FILE=cvisual27-32bit.vcproj
     set PLATFORM=Win32
 ) else (
-    set PROJECT_FILE="cvisual27.vcproj"
+    set PROJECT_FILE=cvisual27.vcproj
     set PLATFORM=x64
 )
 
@@ -13,7 +13,7 @@ set INCLUDE="%PREFIX%\include\boost-1_55";"%PREFIX%"\include;"%PREFIX%\lib\site-
 set LIB="%PREFIX%\libs";"%PREFIX%\lib";%LIB%
 
 cd %SRC_DIR%
-msbuild VCBuild\%PROJECT_FILE% /property:Configuration=Release /property:Platform=%PLATFORM% /p:"VCBuildAdditionalOptions=/useenv"
+msbuild "VCBuild\%PROJECT_FILE%" /property:Configuration=Release /property:Platform=%PLATFORM% /p:"VCBuildAdditionalOptions=/useenv"
 if errorlevel 1 exit 1
 
 xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\visual  "%PREFIX%"\lib\site-packages\visual

--- a/vpython/bld.bat
+++ b/vpython/bld.bat
@@ -1,12 +1,19 @@
 REM Set up environment for building with MSVC
 
-REM call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
+if %ARCH% == "32" (
+    call "C:\Program Files\Microsoft Visual Studio 9.0\Common7\Tools\vsvars32.bat"
+    set PROJECT_FILE="cvisual27-32bit.vcproj"
+    set PLATFORM=Win32
+) else (
+    set PROJECT_FILE="cvisual27.vcproj"
+    set PLATFORM=x64
+)
 
 set INCLUDE="%PREFIX%\include\boost-1_55";"%PREFIX%"\include;"%PREFIX%\lib\site-packages\numpy\core\include";%INCLUDE%
 set LIB="%PREFIX%\libs";"%PREFIX%\lib";%LIB%
 
 cd %SRC_DIR%
-msbuild VCBuild\cvisual27.vcproj /property:Configuration=Release /property:Platform=x64 /p:"VCBuildAdditionalOptions=/useenv"
+msbuild VCBuild\%PROJECT_FILE% /property:Configuration=Release /property:Platform=%PLATFORM% /p:"VCBuildAdditionalOptions=/useenv"
 if errorlevel 1 exit 1
 
 xcopy /S /Y /I /Q "%SRC_DIR%"\site-packages\visual  "%PREFIX%"\lib\site-packages\visual

--- a/vpython/build.sh
+++ b/vpython/build.sh
@@ -1,0 +1,1 @@
+python setup.py install

--- a/vpython/meta.yaml
+++ b/vpython/meta.yaml
@@ -6,7 +6,7 @@ source:
     fn: master.zip
     url: https://github.com/AprilArcus/vpython-wx/archive/master.zip
     patches:
-        - vpython.patch
+        - vpython.patch   # [osx]
 build:
     number: 0
 

--- a/vpython/meta.yaml
+++ b/vpython/meta.yaml
@@ -23,3 +23,7 @@ requirements:
         - boost-vpython
         - fonttools
         - ttfquery
+
+about:
+    home: http://vpython.org/
+    license: modified BSD

--- a/vpython/meta.yaml
+++ b/vpython/meta.yaml
@@ -1,0 +1,25 @@
+package:
+    name: vpython
+    version: "6.0.5"
+
+source:
+    fn: master.zip
+    url: https://github.com/AprilArcus/vpython-wx/archive/master.zip
+    patches:
+        - vpython.patch
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - wxpython
+        - numpy
+        - boost-vpython
+    run:
+        - python
+        - polygon2
+        - wxpython
+        - boost-vpython
+        - fonttools
+        - ttfquery

--- a/vpython/meta.yaml
+++ b/vpython/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
     fn: master.zip
-    url: https://github.com/AprilArcus/vpython-wx/archive/master.zip
+    url: https://github.com/BruceSherwood/vpython-wx/archive/master.zip
     patches:
         - vpython.patch   # [osx]
 build:

--- a/vpython/vpython.patch
+++ b/vpython/vpython.patch
@@ -1,0 +1,22 @@
+diff --git setup.py setup.py
+index c7b1988..2e45a09 100644
+--- setup.py
++++ setup.py
+@@ -87,7 +87,7 @@ elif os_host == 'mac':
+         #
+         # we have no setup.cfg file, assume boost is in 'dependencies'
+         #
+-        BOOST_DIR = os.path.join(VISUAL_DIR,os.path.join('dependencies','boost_files')) 
++        BOOST_DIR = os.path.join(os.environ['PREFIX'], 'include')
+         BOOST_LIBDIR = os.path.join(BOOST_DIR,'mac_libs')
+         LIBRARY_DIRS = [BOOST_LIBDIR]
+     else:
+@@ -133,7 +133,7 @@ for pattern in patterns:
+     VISUAL_SOURCES.extend(glob(VISUAL_DIR + pattern)) 
+  
+ if os_host == 'mac': 
+-    os.environ['LDFLAGS'] = '-framework Cocoa -framework OpenGL -framework Python'
++    os.environ['LDFLAGS'] = ('-framework Cocoa -framework OpenGL ')
+ elif os_host == 'linux': 
+     os.environ['LD_FLAGS'] = LINK_FLAGS 
+  


### PR DESCRIPTION
@asmeurer -- this is the set of recipes discussed a couple months ago in this thread [1]. 

Most of it is straightforward except the boost recipe. My recollection was that the current boost recipe didn't work with vpython (or maybe I couldn't build it at all?), so I created a separate boost recipe in boost-vpython that builds only those pieces of boost needed for vpython.

Also pinging @brucesherwood and @sspickle because they are the primary maintainers of vpython itself (though I've appropriated responsibility for the conda recipe).

[1] https://groups.google.com/a/continuum.io/forum/#!searchin/anaconda/vpython/anaconda/6fraNlCpyDo/vS1A84g_gLYJ
