### PR TITLE
Make boost (1.55.0) built with OSX 10.9 and Xcode 5.1.

### DIFF
--- a/boost/1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch
+++ b/boost/1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch
@@ -1,0 +1,25 @@
+From 9127260dea5092a7fb845cf24758a7cd07156207 Mon Sep 17 00:00:00 2001
+From: Lars Viklund <zao@zao.se>
+Date: Tue, 2 Jul 2013 01:11:29 +0200
+Subject: [PATCH 5/6] Boost.S11n include missing algorithm
+
+---
+ boost/archive/iterators/transform_width.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/boost/archive/iterators/transform_width.hpp b/boost/archive/iterators/transform_width.hpp
+index 3562144..f95c675 100644
+--- a/boost/archive/iterators/transform_width.hpp
++++ b/boost/archive/iterators/transform_width.hpp
+@@ -30,6 +30,8 @@
+ #include <boost/iterator/iterator_adaptor.hpp>
+ #include <boost/iterator/iterator_traits.hpp>
+ 
++#include <algorithm>
++
+ namespace boost { 
+ namespace archive {
+ namespace iterators {
+-- 
+1.8.3.msysgit.0
+

--- a/boost/1.55.0_patches/6bb71fdd.diff
+++ b/boost/1.55.0_patches/6bb71fdd.diff
@@ -1,0 +1,35 @@
+diff --git a/include/boost/atomic/detail/cas128strong.hpp b/include/boost/atomic/detail/cas128strong.hpp
+index 906c13e..dcb4d7d 100644
+--- a/include/boost/atomic/detail/cas128strong.hpp
++++ b/include/boost/atomic/detail/cas128strong.hpp
+@@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void
+     store(value_type const& value, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type value_s = 0;
++        storage_type value_s;
++        memset(&value_s, 0, sizeof(value_s));
+         memcpy(&value_s, &value, sizeof(value_type));
+         platform_fence_before_store(order);
+         platform_store128(value_s, &v_);
+@@ -247,7 +249,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+ 

--- a/boost/1.55.0_patches/e4bde20f.diff
+++ b/boost/1.55.0_patches/e4bde20f.diff
@@ -1,0 +1,55 @@
+diff --git a/include/boost/atomic/detail/gcc-atomic.hpp b/include/boost/atomic/detail/gcc-atomic.hpp
+index a130590..4af99a1 100644
+--- a/include/boost/atomic/detail/gcc-atomic.hpp
++++ b/include/boost/atomic/detail/gcc-atomic.hpp
+@@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
+ 
+ public:
+     BOOST_DEFAULTED_FUNCTION(base_atomic(void), {})
+-    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT : v_(0)
++    explicit base_atomic(value_type const& v) BOOST_NOEXCEPT
+     {
++        memset(&v_, 0, sizeof(v_));
+         memcpy(&v_, &v, sizeof(value_type));
+     }
+ 
+     void store(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         __atomic_store_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+     }
+@@ -980,7 +982,8 @@ class base_atomic<T, void, 16, Sign>
+ 
+     value_type exchange(value_type const& v, memory_order order = memory_order_seq_cst) volatile BOOST_NOEXCEPT
+     {
+-        storage_type tmp = 0;
++        storage_type tmp;
++        memset(&tmp, 0, sizeof(tmp));
+         memcpy(&tmp, &v, sizeof(value_type));
+         tmp = __atomic_exchange_n(&v_, tmp, atomics::detail::convert_memory_order_to_gcc(order));
+         value_type res;
+@@ -994,7 +997,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, false,
+@@ -1010,7 +1015,9 @@ class base_atomic<T, void, 16, Sign>
+         memory_order success_order,
+         memory_order failure_order) volatile BOOST_NOEXCEPT
+     {
+-        storage_type expected_s = 0, desired_s = 0;
++        storage_type expected_s, desired_s;
++        memset(&expected_s, 0, sizeof(expected_s));
++        memset(&desired_s, 0, sizeof(desired_s));
+         memcpy(&expected_s, &expected, sizeof(value_type));
+         memcpy(&desired_s, &desired, sizeof(value_type));
+         const bool success = __atomic_compare_exchange_n(&v_, &expected_s, desired_s, true,

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -3,17 +3,55 @@
 # Hints:
 # http://boost.2283326.n4.nabble.com/how-to-build-boost-with-bzip2-in-non-standard-location-td2661155.html
 # http://www.gentoo.org/proj/en/base/amd64/howtos/?part=1&chap=3
+# http://www.boost.org/doc/libs/1_55_0/doc/html/bbv2/reference.html
+
+# Hints for OSX:
+# http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
 
 # Build dependencies:
 # - bzip2-devel
 
-export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC -shared"
-export CXXFLAGS="${CFLAGS}"
+PATCH_DIR=${RECIPE_DIR}/1.55.0_patches
 
 mkdir -vp ${PREFIX}/bin;
 
-./bootstrap.sh --prefix="${PREFIX}/";
-./b2 install;
+if [ `uname` == Darwin ]; then
+  MACOSX_VERSION_MIN=10.8
+  CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+  CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
+  LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN} "
+  LINKFLAGS="${LINKFLAGS} -stdlib=libc++"
+
+  # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
+  # https://github.com/Homebrew/homebrew/issues/27396
+  # https://github.com/Homebrew/homebrew/pull/27436
+  patch -Np2 -i ${PATCH_DIR}/6bb71fdd.diff
+  patch -Np2 -i ${PATCH_DIR}/e4bde20f.diff
+  # Patch boost::serialization for Clang
+  # https://svn.boost.org/trac/boost/ticket/8757
+  patch -Np1 -i ${PATCH_DIR}/0005-Boost.S11n-include-missing-algorithm.patch
+
+  B2ARGS="toolset=clang"
+
+  ./bootstrap.sh \
+    --prefix="${PREFIX}/" --libdir="${PREFIX}/lib/" \
+    | tee bootstrap.log 2>&1
+  ./b2 \
+    variant=release address-model=64 architecture=x86 \
+    threading=multi link=shared ${B2ARGS} \
+    cxxflags="${CXXFLAGS}" linkflags="${LINKFLAGS}" \
+    install | tee b2.log 2>&1
+else
+  B2ARGS="toolset=gcc"
+
+  ./bootstrap.sh \
+    --prefix="${PREFIX}/" --libdir="${PREFIX}/lib/" \
+    | tee bootstrap.log 2>&1
+  ./b2 \
+    variant=release address-model=64 architecture=x86 \
+    threading=multi link=shared ${B2ARGS} \
+    install | tee b2.log 2>&1
+fi
 
 #POST_LINK="${PREFIX}/bin/.boost-post-link.sh"
 #cp -v ${RECIPE_DIR}/post-link.sh ${POST_LINK};

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -8,11 +8,11 @@ source:
     url: http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
-
+        - python
     run:
 
 test:


### PR DESCRIPTION
The old recipe can't build on OSX (10.9 is the version I tested).  With the patches and new recipe it can now be built with both Debian and OSX.
