### PR TITLE
recipes for Qt5/sip/PyQt5 stack on windows, linux, osx

### DIFF
--- a/icu/bld.bat
+++ b/icu/bld.bat
@@ -1,3 +1,9 @@
-xcopy lib64\* "%PREFIX%\Library\lib\" /E
 xcopy include\* "%PREFIX%\Library\include\" /E
-xcopy bin64\*.dll "%PREFIX%\Scripts\" /E
+IF %ARCH%==64 (
+    xcopy lib64\* "%PREFIX%\Library\lib\" /E
+    xcopy bin64\*.dll "%PREFIX%\Scripts\" /E
+    )
+IF %ARCH%==32 (
+    xcopy lib\* "%PREFIX%\Library\lib\" /E
+    xcopy bin\*.dll "%PREFIX%\Scripts\" /E
+    )

--- a/icu/bld.bat
+++ b/icu/bld.bat
@@ -1,3 +1,3 @@
-xcopy lib64\* %PREFIX%\Library\lib\ /E
-xcopy include\* %PREFIX%\Library\include\ /E
-xcopy bin64\*.dll %PREFIX%\Scripts\ /E
+xcopy lib64\* "%PREFIX%\Library\lib\" /E
+xcopy include\* "%PREFIX%\Library\include\" /E
+xcopy bin64\*.dll "%PREFIX%\Scripts\" /E

--- a/icu/bld.bat
+++ b/icu/bld.bat
@@ -1,0 +1,3 @@
+xcopy lib64\* %PREFIX%\Library\lib\ /E
+xcopy include\* %PREFIX%\Library\include\ /E
+xcopy bin64\*.dll %PREFIX%\Scripts\ /E

--- a/icu/meta.yaml
+++ b/icu/meta.yaml
@@ -1,17 +1,14 @@
 package:
   name: icu
-  version: 53.1
+  version: 54.1
 
 source:
-#  fn: icu4c-53_1-src.zip # [win]
-#  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-src.zip # [win]
-#  md5: a2795d3c23f063179046cdf5359a0389 # [win]
-  fn: icu4c-53_1-Win64-msvc10.zip # [win64]
-  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win64-msvc10.zip # [win64]
-  md5: 3d36641e0ae7a93cd3ce5b35ce7d8961 # [win64]
-  fn: icu4c-53_1-Win32-msvc10.zip # [win32]
-  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win32-msvc10.zip # [win32]
-  md5: 57a8bfd78d4c68582c2c976c7d842f03 # [win32]
+  fn: icu4c-54_1-Win64-msvc10.zip # [win64]
+  url: http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-Win64-msvc10.zip # [win64]
+  md5: 4d85e1817a5a59582517262b9396c7ba # [win64]
+  fn: icu4c-54_1-Win32-msvc10.zip # [win32]
+  url: http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-Win32-msvc10.zip # [win32]
+  md5: 2419927dae9f0ac2498b10de657ff6d3 # [win32]
 
 about:
     home: http://site.icu-project.org/

--- a/icu/meta.yaml
+++ b/icu/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: icu
+  version: 53.1
+
+source:
+#  fn: icu4c-53_1-src.zip # [win]
+#  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-src.zip # [win]
+#  md5: a2795d3c23f063179046cdf5359a0389 # [win]
+  fn: icu4c-53_1-Win64-msvc10.zip # [win]
+  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win64-msvc10.zip # [win]
+  md5: 3d36641e0ae7a93cd3ce5b35ce7d8961 # [win]
+
+about:
+    home: http://site.icu-project.org/
+    license: MIT

--- a/icu/meta.yaml
+++ b/icu/meta.yaml
@@ -6,9 +6,12 @@ source:
 #  fn: icu4c-53_1-src.zip # [win]
 #  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-src.zip # [win]
 #  md5: a2795d3c23f063179046cdf5359a0389 # [win]
-  fn: icu4c-53_1-Win64-msvc10.zip # [win]
-  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win64-msvc10.zip # [win]
-  md5: 3d36641e0ae7a93cd3ce5b35ce7d8961 # [win]
+  fn: icu4c-53_1-Win64-msvc10.zip # [win64]
+  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win64-msvc10.zip # [win64]
+  md5: 3d36641e0ae7a93cd3ce5b35ce7d8961 # [win64]
+  fn: icu4c-53_1-Win32-msvc10.zip # [win32]
+  url: http://download.icu-project.org/files/icu4c/53.1/icu4c-53_1-Win32-msvc10.zip # [win32]
+  md5: 57a8bfd78d4c68582c2c976c7d842f03 # [win32]
 
 about:
     home: http://site.icu-project.org/

--- a/jom/bld.bat
+++ b/jom/bld.bat
@@ -1,1 +1,2 @@
-xcopy * %PREFIX%\Scripts\ /E
+xcopy ibjom.cmd %PREFIX%\Scripts\ /E
+xcopy jom.exe %PREFIX%\Scripts\ /E

--- a/jom/bld.bat
+++ b/jom/bld.bat
@@ -1,0 +1,1 @@
+xcopy * %PREFIX%\Scripts\ /E

--- a/jom/meta.yaml
+++ b/jom/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: jom
+  version: 1.0.14
+
+source:
+  fn: jom_1_0_14.zip # [win]
+  url: http://download.qt-project.org/official_releases/jom/jom_1_0_14.zip # [win]
+  sha1: 5ae36ead8f0a877578b961acea80705416d23374 # [win]
+
+about:
+    home: http://qt-project.org/wiki/jom
+    license: LGPL

--- a/pymqi/build.sh
+++ b/pymqi/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$PYTHON setup.py install

--- a/pymqi/meta.yaml
+++ b/pymqi/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: pymqi
+  version: 1.3
+
+source:
+  fn: pymqi-1.3.tar.gz
+  url: https://pypi.python.org/packages/source/p/pymqi/pymqi-1.3.tar.gz
+  md5: 95eae1fa448bf6875ac7d898d3148e85
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - distribute
+  run:
+    - python
+    - distribute
+
+test:
+  imports:
+    - pymqi
+
+about:
+  home: https://github.com/dsuch/pymqi
+  license: PSF License
+
+# vim:set ts=8 sw=2 sts=2 tw=78 et:

--- a/pyqt/bld.bat
+++ b/pyqt/bld.bat
@@ -1,0 +1,19 @@
+:: assumes executable was installed to C:\staging, and that the documentation,
+:: examples, and start menu shortcuts were not selected for installation
+
+xcopy C:\staging\Lib %PREFIX%\Lib /e /i /q
+del %SP_DIR%\sip.pyd
+del %SP_DIR%\PyQt4\sip.exe
+del %SP_DIR%\PyQt4\qt.conf
+del %SP_DIR%\PyQt4\Uninstall.exe
+move %SP_DIR%\PyQt4\sip %PREFIX%\sip
+
+mkdir %PREFIX%\Scripts
+
+@echo off
+echo @echo off > %PREFIX%\Scripts\pyuic.bat
+echo "%%~dp0\..\python.exe" "%%~dp0\..\Lib\site-packages\PyQt4\uic\pyuic.py" %%* >> %PREFIX%\Scripts\pyuic.bat
+
+echo @echo off > %PREFIX%\Scripts\pyrcc4.bat
+echo "%%~dp0\..\Lib\site-packages\PyQt4\pyrcc4" %%* >> %PREFIX%\Scripts\pyrcc4.bat
+@echo on

--- a/pyqt/meta.yaml
+++ b/pyqt/meta.yaml
@@ -1,27 +1,27 @@
 package:
   name: pyqt
-  version: 4.10.4
+  version: "4.11.1"
 
-source:
-  fn: PyQt-mac-gpl-4.10.4.tar.gz                                                               # [osx]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.10.4/PyQt-mac-gpl-4.10.4.tar.gz # [osx]
-  sha1: ef3bb2a05a5c8c3ab7578a0991ef5a4e17c314c0                                               # [osx]
-  fn: PyQt-x11-gpl-4.10.4.tar.gz                                                               # [linux]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.10.4/PyQt-x11-gpl-4.10.4.tar.gz # [linux]
-  sha1: 33243462987a0ff135487855e2dcd1de1834d1fa                                               # [linux]
-  patches:
-    - configure.patch
+source: # [unix]
+  fn: PyQt-mac-gpl-4.11.1.tar.gz # [osx]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.1/PyQt-mac-gpl-4.11.1.tar.gz # [osx]
+  sha1: 9d7478758957c60ac5007144a0dc7f157f4a5836 # [osx]
+  fn: PyQt-x11-gpl-4.11.1.tar.gz # [linux]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.1/PyQt-x11-gpl-4.11.1.tar.gz # [linux]
+  sha1: 83a0740545d51c179a1b316b664b0f9ff5e0f5af # [linux]
+  patches: # [unix]
+    - configure.patch # [unix]
 
 requirements:
-  build:
-    - python
-    - qt
-    - sip
+  build: # [unix]
+    - python # [unix]
+    - qt # [unix]
+    - sip >=4.16.2 # [unix]
 
   run:
     - python
-    - qt
-    - sip
+    - qt # [unix]
+    - sip >=4.16.2
 
 test:
   imports:

--- a/pyqt/notes.md
+++ b/pyqt/notes.md
@@ -1,0 +1,8 @@
+== Windows ==
+
+Building the pyqt conda package for windows requires special preparation. The
+recipe assumes you have run the executables from Riverbank Computing and
+installed into `C:\staging`. This directory should not exist before installing
+to that location, i.e., it should not be a working python environment. The
+pyqt recipe's bld.bat just copies the contents of `C:\staging` into our conda
+build environment.

--- a/pyqt/notes.md
+++ b/pyqt/notes.md
@@ -1,8 +1,24 @@
 == Windows ==
 
-Building the pyqt conda package for windows requires special preparation. The
-recipe assumes you have run the executables from Riverbank Computing and
-installed into `C:\staging`. This directory should not exist before installing
-to that location, i.e., it should not be a working python environment. The
-pyqt recipe's bld.bat just copies the contents of `C:\staging` into our conda
-build environment.
+Building the pyqt conda package for windows requires special
+preparation. The recipe assumes you have run the executables from
+Riverbank Computing and installed into `C:\staging`. This directory
+should not exist before installing to that location, i.e., it should
+not be a working python environment. The pyqt recipe's bld.bat just
+copies the contents of `C:\staging` into our conda build environment.
+
+An alternative approach would be to add a Qt(4) package for windows,
+but then we would need to patch either Qt4 or Qt5 to prevent
+collisions of executables (like 'designer' and 'qmake', the DLLs at
+least do not collide), and also PyQt4 or PyQt5 would have to be
+patched to find the renamed executables.
+
+Another approach to pyqt would be to build PyQt4 against Qt5 for
+python3. This would allow building PyQt4 from source on windows, but
+based on the documentation at
+http://pyqt.sourceforge.net/Docs/PyQt4/qt_v5.html , this approach
+seems to be undesirable in practice, since there could be cases of
+PyQt4-Qt4 code using old-style signals that would need to be altered
+to run with PyQt4-Qt5. And worse, there is the potential of developing
+code with PyQt4-Qt5 that would not run with PyQt4-Qt4, since PyQt4-Qt5
+exposes methods introduced in Qt5 for classes that existed in Qt4.

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -1,7 +1,3 @@
-:: may need to change these depending on environment:
-::CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x6
-CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
-
 :: make sure we pick up the right qmake:
 set PATH=%PREFIX%\Scripts;%PATH%
 

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -1,4 +1,4 @@
-CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+::CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 
 %PYTHON% configure.py ^
         --spec=win32-msvc2010 ^

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -1,0 +1,15 @@
+:: may need to change these depending on environment:
+::CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x6
+CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
+
+:: make sure we pick up the right qmake:
+set PATH=%PREFIX%\Scripts;%PATH%
+
+%PYTHON% configure.py ^
+        --verbose ^
+        --confirm-license ^
+        --assume-shared ^
+        --bindir=%PREFIX%\Scripts
+
+jom
+nmake install

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -1,10 +1,12 @@
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+
 :: make sure we pick up the right qmake:
 set PATH=%PREFIX%\Scripts;%PATH%
 
 %PYTHON% configure.py ^
+        --assume-shared ^
         --verbose ^
         --confirm-license ^
-        --assume-shared ^
         --bindir=%PREFIX%\Scripts
 
 jom

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -1,9 +1,7 @@
 CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 
-:: make sure we pick up the right qmake:
-set PATH=%PREFIX%\Scripts;%PATH%
-
 %PYTHON% configure.py ^
+        --spec=win32-msvc2010 ^
         --assume-shared ^
         --verbose ^
         --confirm-license ^

--- a/pyqt5/bld.bat
+++ b/pyqt5/bld.bat
@@ -8,4 +8,4 @@ CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
         --bindir=%PREFIX%\Scripts
 
 jom
-nmake install
+jom install

--- a/pyqt5/build.sh
+++ b/pyqt5/build.sh
@@ -4,7 +4,7 @@ if [ `uname` == Darwin ]; then
 fi
 
 if [ `uname` == Linux ]; then
-    MAKE_JOBS=$(nproc)
+    MAKE_JOBS=$CPU_COUNT
 fi
 
 $PYTHON configure.py \

--- a/pyqt5/build.sh
+++ b/pyqt5/build.sh
@@ -1,0 +1,17 @@
+if [ `uname` == Darwin ]; then
+    export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib
+    MAKE_JOBS=$(sysctl -n hw.ncpu)
+fi
+
+if [ `uname` == Linux ]; then
+    MAKE_JOBS=$(nproc)
+fi
+
+$PYTHON configure.py \
+        --verbose \
+        --confirm-license \
+        --assume-shared \
+        -q $PREFIX/bin/qmake-qt5
+
+make -j $MAKE_JOBS
+make install

--- a/pyqt5/meta.yaml
+++ b/pyqt5/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
 test:
   imports:
-    - PyQt5
+    - PyQt5.QtCore
 
 about:
   home: http://www.riverbankcomputing.co.uk/software/pyqt

--- a/pyqt5/meta.yaml
+++ b/pyqt5/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: pyqt5
+  version: 5.3.1
+
+source:
+  fn: PyQt-gpl-5.3.1.zip # [win]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.1/PyQt-gpl-5.3.1.zip # [win]
+  sha1: 446ff0f29f5fd6f7fbadb5a9b36ef8cced10a322 # [win]
+  fn: PyQt-gpl-5.3.1.tar.gz # [unix]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.1/PyQt-gpl-5.3.1.tar.gz # [unix]
+  sha1: c3554c33cfe589afb3e3a4ca2ad87e325da30945 # [unix]
+
+
+requirements:
+  build:
+    - python
+    - qt5 >=5.3.0
+    - sip >=4.16.2
+    - jom # [win]
+
+  run:
+    - python
+    - qt5 >=5.3.0
+    - sip >=4.16.2
+
+test:
+  imports:
+    - PyQt5
+
+about:
+  home: http://www.riverbankcomputing.co.uk/software/pyqt
+  license: GPL

--- a/pyqt5/meta.yaml
+++ b/pyqt5/meta.yaml
@@ -1,29 +1,29 @@
 package:
   name: pyqt5
-  version: 5.3.2
+  version: 5.4
 
 source:
-  fn: PyQt-gpl-5.3.2.zip # [win]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.2/PyQt-gpl-5.3.2.zip # [win]
-  sha1: e8a0a1db25cbbf14bedca976f6ffb15dac2ecc35 # [win]
-  fn: PyQt-gpl-5.3.2.tar.gz # [unix]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.2/PyQt-gpl-5.3.2.tar.gz # [unix]
-  sha1: bb34d826a50b0735d1319dc51be6a094ba64b800 # [unix]
+  fn: PyQt-gpl-5.4.zip # [win]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4/PyQt-gpl-5.4.zip # [win]
+  sha1: 3d3967025ca4019356c0b2a81e046ff08ca07d9b # [win]
+  fn: PyQt-gpl-5.4.tar.gz # [unix]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4/PyQt-gpl-5.4.tar.gz # [unix]
+  sha1: 057e6b32c43e673e79f876fb9b6f33d3072edfc2 # [unix]
 
-  patches: # [osx]
-    - configure.patch # [osx] may not be required for >5.3.2
+  #patches: # [osx]
+  #  - configure.patch # [osx] may not be required for >5.3.2
 
 requirements:
   build:
     - python
-    - qt5 >=5.3.0
-    - sip >=4.16.2
+    - qt5 >=5.4.0
+    - sip >=4.16.5
     - jom # [win]
 
   run:
     - python
-    - qt5 >=5.3.0
-    - sip >=4.16.2
+    - qt5 >=5.4.0
+    - sip >=4.16.5
 
 test:
   imports:

--- a/qt5/5.3.1_patch_files.txt
+++ b/qt5/5.3.1_patch_files.txt
@@ -1,0 +1,8 @@
+Library/lib/qt5/Qt5AxBase.prl
+Library/lib/qt5/Qt5AxContainer.prl
+Library/lib/qt5/Qt5AxServer.prl
+Library/lib/qt5/Qt5OpenGLExtensions.prl
+Library/lib/qt5/Qt5PlatformSupport.prl
+Library/lib/qt5/Qt5QmlDevTools.prl
+Library/lib/qt5/Qt5UiTools.prl
+Library/lib/qt5/qtmain.prl

--- a/qt5/README.md
+++ b/qt5/README.md
@@ -1,0 +1,6 @@
+qt5-conda-recipe
+================
+
+Strategy for a qt5 conda package that can be installed alongside qt(4), largely taken from http://www.linuxfromscratch.org/blfs/view/7.4/x/qt5.html , installing executables to `$PREFIX/qt5/bin` and making links in `$PREFIX/bin` with names like `designer-qt5`. (A different approach is now advocated at http://www.linuxfromscratch.org/blfs/view/7.5/x/qt5.html, where a shell script is used to switch between qt4 and qt5 by modifying the `PATH`.)
+
+The second component of this strategy is a more extensive `qt.conf` in `$PREFIX/bin` and `$PREFIX/lib/qt5/bin`, so all of the appropriate paths can be found. Documentation on the use of `qt.conf` can be found at http://qt-project.org/doc/qt-5/qt-conf.html

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -1,7 +1,3 @@
-:: may need to change these depending on environment:
-CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-::CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
-
 :: set path to find resources shipped with qt-5:
 set PATH=%SRC_DIR%\gnuwin32\bin;%PATH%
 
@@ -14,7 +10,7 @@ set PATH=C:\OpenSSL-Win64\bin;%PATH%
 set SQLITE3SRCDIR=%SRC_DIR%\qtbase\src\3rdparty\sqlite
 
 :: this needs to be CALLed due to an exit statement at the end of configure:
-CALL configure -platform win32-msvc2010 ^
+CALL configure ^
       -prefix %PREFIX%\Library ^
       -libdir %PREFIX%\Library\lib ^
       -bindir %PREFIX%\Scripts ^

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -1,3 +1,7 @@
+:: need to reset the environment here, or will not compile with errors
+:: similar to http://qt-project.org/forums/viewthread/32660 
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+
 :: set path to find resources shipped with qt-5:
 set PATH=%SRC_DIR%\gnuwin32\bin;%PATH%
 
@@ -10,14 +14,15 @@ set PATH=C:\OpenSSL-Win64\bin;%PATH%
 set SQLITE3SRCDIR=%SRC_DIR%\qtbase\src\3rdparty\sqlite
 
 :: this needs to be CALLed due to an exit statement at the end of configure:
-CALL configure ^
+CALL configure -platform win32-msvc2010 ^
       -prefix %PREFIX%\Library ^
-      -libdir %PREFIX%\Library\lib ^
+      -libdir %PREFIX%\Library\lib\qt5 ^
       -bindir %PREFIX%\Scripts ^
       -headerdir %PREFIX%\Library\include\qt5 ^
       -archdatadir %PREFIX%\Library\lib\qt5 ^
       -datadir %PREFIX%\Library\share\qt5 ^
       -release ^
+      -shared ^
       -opensource ^
       -confirm-license ^
       -no-warnings-are-errors ^
@@ -36,3 +41,5 @@ nmake install
 
 :: remove docs, phrasebooks, translations
 rmdir %PREFIX%\Library\share\qt5 /s /q
+
+%PYTHON% %RECIPE_DIR%\patch_prefix_files.py

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -1,7 +1,3 @@
-:: need to reset the environment here, or will not compile with errors
-:: similar to http://qt-project.org/forums/viewthread/32660
-CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-
 :: set path to find resources shipped with qt-5
 :: see http://doc-snapshot.qt-project.org/qt5-5.4/windows-building.html
 set PATH=%SRC_DIR%\qtbase\bin;%SRC_DIR%\gnuwin32\bin;%PATH%

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -6,16 +6,16 @@ CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 set PATH=%SRC_DIR%\gnuwin32\bin;%PATH%
 
 :: make sure we can find ICU and openssl:
-set INCLUDE=%PREFIX%\include;C:\OpenSSL-Win64\include;%INCLUDE%
-set LIB=%PREFIX%\libs;C:\OpenSSL-Win64\lib;%LIB%
-set PATH=C:\OpenSSL-Win64\bin;%PATH%
+set INCLUDE=%PREFIX%\Library\include;C:\OpenSSL-Win64\include;%INCLUDE%
+set LIB=%PREFIX%\Library\lib;C:\OpenSSL-Win64\lib;%LIB%
+set PATH=%PREFIX%\Scripts;C:\OpenSSL-Win64\bin;%PATH%
 
 :: make sure we can find sqlite3:
 set SQLITE3SRCDIR=%SRC_DIR%\qtbase\src\3rdparty\sqlite
 
 :: this needs to be CALLed due to an exit statement at the end of configure:
 CALL configure -platform win32-msvc2010 ^
-      -prefix %PREFIX%\Library ^
+      -prefix %PREFIX% ^
       -libdir %PREFIX%\Library\lib\qt5 ^
       -bindir %PREFIX%\Scripts ^
       -headerdir %PREFIX%\Library\include\qt5 ^

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -1,9 +1,11 @@
 :: need to reset the environment here, or will not compile with errors
-:: similar to http://qt-project.org/forums/viewthread/32660 
+:: similar to http://qt-project.org/forums/viewthread/32660
 CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
 
-:: set path to find resources shipped with qt-5:
-set PATH=%SRC_DIR%\gnuwin32\bin;%PATH%
+:: set path to find resources shipped with qt-5
+:: see http://doc-snapshot.qt-project.org/qt5-5.4/windows-building.html
+set PATH=%SRC_DIR%\qtbase\bin;%SRC_DIR%\gnuwin32\bin;%PATH%
+set QMAKESPEC=win32-msvc2010
 
 :: make sure we can find ICU and openssl:
 set INCLUDE=%PREFIX%\Library\include;C:\OpenSSL-Win64\include;%INCLUDE%
@@ -12,6 +14,8 @@ set PATH=%PREFIX%\Scripts;C:\OpenSSL-Win64\bin;%PATH%
 
 :: make sure we can find sqlite3:
 set SQLITE3SRCDIR=%SRC_DIR%\qtbase\src\3rdparty\sqlite
+
+:: See http://doc-snapshot.qt-project.org/qt5-5.4/windows-requirements.html
 
 :: this needs to be CALLed due to an exit statement at the end of configure:
 CALL configure -platform win32-msvc2010 ^
@@ -33,11 +37,12 @@ CALL configure -platform win32-msvc2010 ^
       -qt-libpng ^
       -qt-zlib ^
       -qt-libjpeg ^
-      -opengl desktop
+      -icu ^
+      -opengl dynamic
 
 :: jom is nmake alternative with multicore support, uses all cores by default
 jom
-nmake install
+jom install
 
 :: remove docs, phrasebooks, translations
 rmdir %PREFIX%\Library\share\qt5 /s /q

--- a/qt5/bld.bat
+++ b/qt5/bld.bat
@@ -1,0 +1,42 @@
+:: may need to change these depending on environment:
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+::CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
+
+:: set path to find resources shipped with qt-5:
+set PATH=%SRC_DIR%\gnuwin32\bin;%PATH%
+
+:: make sure we can find ICU and openssl:
+set INCLUDE=%PREFIX%\include;C:\OpenSSL-Win64\include;%INCLUDE%
+set LIB=%PREFIX%\libs;C:\OpenSSL-Win64\lib;%LIB%
+set PATH=C:\OpenSSL-Win64\bin;%PATH%
+
+:: make sure we can find sqlite3:
+set SQLITE3SRCDIR=%SRC_DIR%\qtbase\src\3rdparty\sqlite
+
+:: this needs to be CALLed due to an exit statement at the end of configure:
+CALL configure -platform win32-msvc2010 ^
+      -prefix %PREFIX%\Library ^
+      -libdir %PREFIX%\Library\lib ^
+      -bindir %PREFIX%\Scripts ^
+      -headerdir %PREFIX%\Library\include\qt5 ^
+      -archdatadir %PREFIX%\Library\lib\qt5 ^
+      -datadir %PREFIX%\Library\share\qt5 ^
+      -release ^
+      -opensource ^
+      -confirm-license ^
+      -no-warnings-are-errors ^
+      -no-separate-debug-info ^
+      -nomake examples ^
+      -nomake tests ^
+      -fontconfig ^
+      -qt-libpng ^
+      -qt-zlib ^
+      -qt-libjpeg ^
+      -opengl desktop
+
+:: jom is nmake alternative with multicore support, uses all cores by default
+jom
+nmake install
+
+:: remove docs, phrasebooks, translations
+rmdir %PREFIX%\Library\share\qt5 /s /q

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+CONFIG_OPTS=" "
+PATH=/usr/bin:/usr/sbin:/bin
+
+if [ `uname` == Linux ]; then
+    CONFIG_OPTS+=" -dbus"
+    MAKE_JOBS=$(nproc)
+fi
+
+if [ `uname` == Darwin ]; then
+    # Let Qt set its own flags and vars
+    for x in OSX_ARCH CFLAGS CXXFLAGS LDFLAGS
+    do
+        unset $x
+    done
+
+    MACOSX_DEPLOYMENT_TARGET=10.7
+
+    CONFIG_OPTS+=" -platform macx-g++ -no-framework -no-c++11"
+    CONFIG_OPTS+=" -no-mtdev -no-harfbuzz -no-xinput2 -no-xcb-xlib"
+    CONFIG_OPTS+=" -no-libudev -no-egl"
+
+    MAKE_JOBS=$(sysctl -n hw.ncpu)
+fi
+
+chmod +x configure
+./configure -prefix $PREFIX \
+            -libdir $PREFIX/lib \
+            -bindir $PREFIX/lib/qt5/bin \
+            -headerdir $PREFIX/include/qt5 \
+            -archdatadir $PREFIX/lib/qt5 \
+            -datadir $PREFIX/share/qt5 \
+            -release \
+            -opensource \
+            -confirm-license \
+            -shared \
+            -process \
+            -nomake examples \
+            -nomake tests \
+            -fontconfig \
+            -qt-libpng \
+            -qt-zlib \
+            $CONFIG_OPTS
+
+make -j $MAKE_JOBS
+make install
+
+for file in $PREFIX/lib/qt5/bin/*
+do
+    ln -sfv ../lib/qt5/bin/$(basename $file) $PREFIX/bin/$(basename $file)-qt5
+done
+
+#removes doc, phrasebooks, and translations
+rm -rf $PREFIX/share/qt5

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -5,7 +5,7 @@ PATH=/usr/bin:/usr/sbin:/bin
 
 if [ `uname` == Linux ]; then
     CONFIG_OPTS+=" -dbus"
-    MAKE_JOBS=$(nproc)
+    MAKE_JOBS=$CPU_COUNT
 fi
 
 if [ `uname` == Darwin ]; then

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -10,15 +10,12 @@ source:
   url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.zip # [win]
   sha1: 4695389cacd256aef25fc42ce27e15355e44bff5 # [win]
 
-  patches: # [win and py2k]
-    - msvc2008.patch # [win and py2k]
-
 build:
   number: 1
   binary_has_prefix_files:
     - lib/qt5/bin/qmake # [unix]
-    - Scripts\qmake.exe # [win]
-    - Scripts\Qt5Core.dll # [win]
+    - Scripts/qmake.exe # [win]
+    - Scripts/Qt5Core.dll # [win]
     - lib/libQt5Core.so # [linux]
     - lib/libQt5Core.dylib # [osx]
     - lib/libQt5Core.la # [osx]
@@ -28,11 +25,11 @@ requirements:
     - freetype # [unix]
     - icu # [win]
     - jom # [win]
-    - python
+    - python # [win]
   run:
     - freetype # [unix]
     - icu # [win]
-    - python # [win]
+
 
 about:
     home: http://qt-project.org

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -12,14 +12,14 @@ source:
 
 build:
   number: 1
-  detect_binary_files_with_prefix: true
-#  binary_has_prefix_files:
-#    - lib/qt5/bin/qmake # [unix]
-#    - Scripts/qmake.exe # [win]
-#    - Scripts/Qt5Core.dll # [win]
-#    - lib/libQt5Core.so # [linux]
-#    - lib/libQt5Core.dylib # [osx]
-#    - lib/libQt5Core.la # [osx]
+#  detect_binary_files_with_prefix: true
+  binary_has_prefix_files:
+    - lib/qt5/bin/qmake # [unix]
+    - Scripts/qmake.exe # [win]
+    - Scripts/Qt5Core.dll # [win]
+    - lib/libQt5Core.so # [linux]
+    - lib/libQt5Core.dylib # [osx]
+    - lib/libQt5Core.la # [osx]
 
 requirements:
   build:

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -12,13 +12,14 @@ source:
 
 build:
   number: 1
-  binary_has_prefix_files:
-    - lib/qt5/bin/qmake # [unix]
-    - Scripts/qmake.exe # [win]
-    - Scripts/Qt5Core.dll # [win]
-    - lib/libQt5Core.so # [linux]
-    - lib/libQt5Core.dylib # [osx]
-    - lib/libQt5Core.la # [osx]
+  detect_binary_files_with_prefix: true
+#  binary_has_prefix_files:
+#    - lib/qt5/bin/qmake # [unix]
+#    - Scripts/qmake.exe # [win]
+#    - Scripts/Qt5Core.dll # [win]
+#    - lib/libQt5Core.so # [linux]
+#    - lib/libQt5Core.dylib # [osx]
+#    - lib/libQt5Core.la # [osx]
 
 requirements:
   build:

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -1,25 +1,17 @@
 package:
   name: qt5
-  version: 5.3.1
+  version: 5.4.0
 
 source:
-  fn: qt-everywhere-opensource-src-5.3.1.tar.gz # [unix]
-  url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.tar.gz # [unix]
-  sha1: 3244dd34f5fb695e903eaa49c6bd0838b9bf7a73 # [unix]
-  fn: qt-everywhere-opensource-src-5.3.1.zip # [win]
-  url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.zip # [win]
-  sha1: 4695389cacd256aef25fc42ce27e15355e44bff5 # [win]
+  fn: qt-everywhere-opensource-src-5.4.0.tar.gz # [unix]
+  url: http://download.qt-project.org/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.gz # [unix]
+  sha1: 06a510e1019f3d42d122b89b912332e804da41e1 # [unix]
+  fn: qt-everywhere-opensource-src-5.4.0.zip # [win]
+  url: http://download.qt-project.org/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.zip # [win]
+  sha1: d098e27e441f6d806c0e56c65f40c57931754acc # [win]
 
 build:
-  number: 1
   detect_binary_files_with_prefix: true
-#  binary_has_prefix_files:
-#    - lib/qt5/bin/qmake # [unix]
-#    - Scripts/qmake.exe # [win]
-#    - Scripts/Qt5Core.dll # [win]
-#    - lib/libQt5Core.so # [linux]
-#    - lib/libQt5Core.dylib # [osx]
-#    - lib/libQt5Core.la # [osx]
 
 requirements:
   build:
@@ -33,5 +25,5 @@ requirements:
 
 
 about:
-    home: http://qt-project.org
+    home: http://www.qt.io
     license: LGPL

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: qt5
+  version: 5.3.1
+
+source:
+  fn: qt-everywhere-opensource-src-5.3.1.tar.gz # [unix]
+  url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.tar.gz # [unix]
+  sha1: 3244dd34f5fb695e903eaa49c6bd0838b9bf7a73 # [unix]
+  fn: qt-everywhere-opensource-src-5.3.1.zip # [win]
+  url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.zip # [win]
+  sha1: 4695389cacd256aef25fc42ce27e15355e44bff5 # [win]
+
+build:
+  number: 1
+  binary_has_prefix_files:
+    - lib/qt5/bin/qmake # [unix]
+    - Scripts\qmake.exe # [win]
+    - Scripts\Qt5Core.dll # [win]
+    - lib/libQt5Core.so # [linux]
+    - lib/libQt5Core.dylib # [osx]
+    - lib/libQt5Core.la # [osx]
+
+requirements:
+  build:
+    - freetype # [unix]
+    - icu # [win]
+    - jom # [win]
+  run:
+    - freetype # [unix]
+    - icu # [win]
+
+about:
+    home: http://qt-project.org
+    license: LGPL

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -10,6 +10,9 @@ source:
   url: http://download.qt-project.org/official_releases/qt/5.3/5.3.1/single/qt-everywhere-opensource-src-5.3.1.zip # [win]
   sha1: 4695389cacd256aef25fc42ce27e15355e44bff5 # [win]
 
+  patches: # [win and py2k]
+    - msvc2008.patch # [win and py2k]
+
 build:
   number: 1
   binary_has_prefix_files:
@@ -25,9 +28,11 @@ requirements:
     - freetype # [unix]
     - icu # [win]
     - jom # [win]
+    - python
   run:
     - freetype # [unix]
     - icu # [win]
+    - python # [win]
 
 about:
     home: http://qt-project.org

--- a/qt5/notes.md
+++ b/qt5/notes.md
@@ -1,0 +1,55 @@
+Building a conda qt5 package is a slow process. Its a big package, and it takes
+a long time to even unpack the compressed source. Its also not possible for
+conda to use a git checkout, because conda caches a bare repository, almost
+all of the source exists as submodules, and conda tries to clone the submodules
+from nonexistent directories in its cache. So we are stuck with the compressed
+source files.
+
+## Packages needed to build with RHEL6
+
+- xcb-util-devel
+
+These may have been optional
+
+- libudev-devel
+- pcre-devel
+- mesa-libEGL
+
+## Notes concerning OS X
+
+- I found it necessary to uninstall the qt4-mac macports package. Qt5 was
+  picking up Qt4 headers.
+- Found apparent race conditions when running make with multiple jobs.
+
+## Notes concerning Windows:
+
+- Building from source requires preparing the environment outside conda
+  (see http://qt-project.org/doc/qt-5/windows-requirements.html):
+
+    * ActivePerl
+    * Ruby
+    * Python (trivial)
+    * DirectX SDK
+    * Visual C++ 2010 (2008 yields compilation errors, see
+      https://bugreports.qt-project.org/browse/QTBUG-36037):
+
+      1. Install Visual Studio 2010
+      2. Install Windows SDK 7.1
+      3. Install Visual Studio 2010 SP1
+      4. Install Visual C++ 2010 SP1 Compiler Update for the Windows SDK 7.1
+      5. Copy glext.h, wglext.h, and glxext.h from
+         http://www.opengl.org/registry/ into
+         `C:\Program Files\ Microsoft SDKs\Windows\v7.1\Include\gl`
+
+  You may also have to edit bld.bat to make sure perl and ruby can be found on
+  the `%PATH%`. I also installed openssl and grep for windows. OpenSSL was
+  necessary for PyQt-5.3.1. The instructions at
+  http://trac.webkit.org/wiki/BuildingQtOnWindows were especially helpful, and
+  include links to build dependencies.
+
+  This recipe assumes the computer on which Qt-5 will be installed has drivers
+  supporting opengl.
+
+  Alternatively, one might consider building with mingw:
+  http://qt-project.org/wiki/MinGW-64-bit . I gave up after failing to build
+  the ICU dependency with MinGW.

--- a/qt5/notes.md
+++ b/qt5/notes.md
@@ -23,15 +23,21 @@ These may have been optional
 
 ## Notes concerning Windows:
 
+- It is possible to build Qt5 with MSVC2008, but I have not been successful
+  building ICU with MSVC2008. The readme.html in ICU's sources explain how to
+  build with older MSVC via cygwin, but I have not been successful. Riverbank
+  Computing does not provide PyQt5 installers for python2.7 on windows, due
+  to the lack of MSVC2008 support. It seems unwise to distribute PyQt5 for py27
+  without upstream support.
+
 - Building from source requires preparing the environment outside conda
   (see http://qt-project.org/doc/qt-5/windows-requirements.html):
 
     * ActivePerl
     * Ruby
     * Python (trivial)
-    * DirectX SDK
-    * Visual C++ 2010 (2008 yields compilation errors, see
-      https://bugreports.qt-project.org/browse/QTBUG-36037):
+    * DirectX SDK (if omitting `-opengl desktop` config argument)
+    * Visual C++ 2010:
 
       1. Install Visual Studio 2010
       2. Install Windows SDK 7.1
@@ -41,15 +47,12 @@ These may have been optional
          http://www.opengl.org/registry/ into
          `C:\Program Files\ Microsoft SDKs\Windows\v7.1\Include\gl`
 
-  You may also have to edit bld.bat to make sure perl and ruby can be found on
-  the `%PATH%`. I also installed openssl and grep for windows. OpenSSL was
-  necessary for PyQt-5.3.1. The instructions at
+  You may also have to make sure perl and ruby can be found on the `%PATH%`. I
+  also installed openssl and grep for windows. OpenSSL was necessary for
+  PyQt-5.3.1 (but should not be for PyQt-5.3.2). The instructions at
   http://trac.webkit.org/wiki/BuildingQtOnWindows were especially helpful, and
   include links to build dependencies.
 
   This recipe assumes the computer on which Qt-5 will be installed has drivers
-  supporting opengl.
-
-  Alternatively, one might consider building with mingw:
-  http://qt-project.org/wiki/MinGW-64-bit . I gave up after failing to build
-  the ICU dependency with MinGW.
+  supporting opengl. It could be rebuilt removing the `-opengl desktop` config
+  parameter to use ANGLE, which ships with the qt5 sources.

--- a/qt5/notes.md
+++ b/qt5/notes.md
@@ -1,9 +1,10 @@
 Building a conda qt5 package is a slow process. Its a big package, and it takes
-a long time to even unpack the compressed source. Its also not possible for
-conda to use a git checkout, because conda caches a bare repository, almost
-all of the source exists as submodules, and conda tries to clone the submodules
-from nonexistent directories in its cache. So we are stuck with the compressed
-source files.
+a long time to even unpack the compressed source. In fact, it takes about as
+long to delete an old qt5 source directory and unpack a new one as it does to
+compile qt5 on a 48-core machine. Its currently not possible for conda to use a
+git checkout, because conda caches a bare repository, almost all of the source
+exists as submodules, and conda tries to clone the submodules from nonexistent
+directories in its cache. So we are stuck with the compressed source files.
 
 ## Packages needed to build with RHEL6
 
@@ -56,3 +57,10 @@ These may have been optional
   This recipe assumes the computer on which Qt-5 will be installed has drivers
   supporting opengl. It could be rebuilt removing the `-opengl desktop` config
   parameter to use ANGLE, which ships with the qt5 sources.
+
+  Qt5, especially QtWebKit, have a few source files with paths that are long
+  enough to cause problems for the MSVC compiler, which has a 260 character
+  constraint. This caused problems when I installed anaconda in
+  `C:\Users\myprofile\anaconda` (particularly when compiling the third-party
+  webp graphics plugin for qtwebkit). Installing anaconda/miniconda in
+  `C:\conda` worked around this issue. 

--- a/qt5/patch_prefix_files.py
+++ b/qt5/patch_prefix_files.py
@@ -1,0 +1,24 @@
+from os import environ
+import sys
+
+PREFIX = environ['PREFIX']
+#PREFIX = "C:\Anaconda\envs\_build_placehold_placehold_placehold_placehold_placehold_placeh"
+PRL_PREFIX = PREFIX.replace('\\', '\\\\') + '\\\\Library\\\\lib\\\\qt5'
+# must include an empty string in the *last* position of this list:
+LIBS = ['\\\\Qt5Core.lib', '\\\\Qt5Gui.lib', '\\\\Qt5Widgets.lib', '']
+PKG_VERSION = environ['PKG_VERSION']
+#PKG_VERSION = "5.3.1"
+RECIPE_DIR = environ['RECIPE_DIR']
+#RECIPE_DIR = "C:\Users\darren\Documents\GitHub\conda-recipes\qt5"
+
+with open('%s/%s_patch_files.txt' % (RECIPE_DIR, PKG_VERSION), 'r') as names:
+    for filename in names:
+        filename = filename[:-1]
+        with open('%s/%s' % (PREFIX, filename), 'rb') as f:
+            data = f.read()
+        for lib in LIBS:
+            old = (PRL_PREFIX+lib).encode('utf-8')
+            new = b'"%s"' % (old.replace(b'\\\\', b'/'))
+            data = data.replace(old, new)
+        with open('%s/%s' % (PREFIX, filename), 'wb') as f:
+            f.write(data)

--- a/qt5/patch_prefix_files.py
+++ b/qt5/patch_prefix_files.py
@@ -15,13 +15,13 @@ LIBS = ['\\\\Qt5Core.lib', '\\\\Qt5Gui.lib', '\\\\Qt5Widgets.lib', '']
 filenames = glob.glob('%s\\*.prl' % LIBQT5)
 
 for filename in filenames:
-    with open(filename, 'rb') as f:
+    with open(filename, 'r') as f:
         old_data = f.read()
     for lib in LIBS:
-        old_path = (PRL_PREFIX+lib).encode('utf-8')
-        new_path = b'"%s"' % (old_path.replace(b'\\\\', b'/'))
+        old_path = PRL_PREFIX + lib
+        new_path = '"%s"' % old_path.replace('\\\\', '/')
         new_data = old_data.replace(old_path, new_path)
     if new_data == old_data:
         continue
     with open(filename, 'wb') as f:
-        f.write(new_data)
+        f.write(new_data.encode('utf8'))

--- a/sip/bld.bat
+++ b/sip/bld.bat
@@ -1,9 +1,4 @@
-:: may need to change these depending on environment:
-CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
-
-%PYTHON% configure.py ^
-    --platform win32-msvc2008 ^
-    --bindir=%PREFIX%\Scripts
+%PYTHON% configure.py --bindir=%PREFIX%\Scripts
 
 nmake
 nmake install

--- a/sip/bld.bat
+++ b/sip/bld.bat
@@ -1,3 +1,9 @@
-%PYTHON% configure.py --platform win32-g++
-make
-make install
+:: may need to change these depending on environment:
+CALL "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcvarsall.bat" amd64
+
+%PYTHON% configure.py ^
+    --platform win32-msvc2008 ^
+    --bindir=%PREFIX%\Scripts
+
+nmake
+nmake install

--- a/sip/meta.yaml
+++ b/sip/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: sip
-  version: 4.16.3
+  version: 4.16.5
 
 source:
-  fn: sip-4.16.3.tar.gz # [unix]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.3/sip-4.16.3.tar.gz # [unix]
-  sha1: 7c4079d164ccbfe4a5274eaeebe8e3cc86e3a75a # [unix]
-  fn: sip-4.16.3.zip # [win]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.3/sip-4.16.3.zip # [win]
-  sha1: 8f77e5edb19ffac5e162f1fe336428ec3c2d9580 # [win]
+  fn: sip-4.16.5.tar.gz # [unix]
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.tar.gz # [unix]
+  sha1: d5d7b6765de8634eccf48a250dbd915f01b2a771 # [unix]
+  fn: sip-4.16.5.zip # [win]
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.zip # [win]
+  sha1: fa6c055a3db805218bd962a9fb182aa0bf91f95e # [win]
 
 requirements:
   build:

--- a/sip/meta.yaml
+++ b/sip/meta.yaml
@@ -1,20 +1,19 @@
 package:
   name: sip
-  version: 4.15.5
+  version: 4.16.2
 
 source:
-  fn: sip-4.15.5.tar.gz                                                            # [not win]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.15.5/sip-4.15.5.tar.gz # [not win]
-  sha1: 1e1c912981930754885ba47d708e2664d1c6ba9e                                   # [not win]
-  fn: sip-4.15.4.zip                                                               # [win]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.15.4/sip-4.15.4.zip    # [win]
-  sha1: 663088693ff9c0656b22e37fed26bfdfe0829562                                   # [win]
+  fn: sip-4.16.2.tar.gz
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.2/sip-4.16.2.tar.gz
+  sha1: 4d3ebce6ec7c31d8a862a6ee307a5f6c3e67349b
+  fn: sip-4.16.2.zip
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.2/sip-4.16.2.zip
+  sha1: 44c50fba4a65ae7b67ba5d469da1560e7a614f07
 
 requirements:
   build:
     - python
     - python.app # [osx]
-    - mingw      # [win]
 
   run:
     - python


### PR DESCRIPTION
Compiles Qt5, sip, and pyqt5 using MSVC Express (tested with 2008 for py27, 2010 for py3k). Uses precompiled ICU binaries (build and runtime requirement for Qt5 on windows), and uses precompiled jom executable to perform the build in parallel.

Qt5 is given a python requirement to differentiate qt5 built with msvc2008 for py27 and qt5 built with msvc2010 for py3k. Linking pyqt5 built with msvc2008 to a qt5 built with msvc2010 resulted in crashes in a few of PyQt5's examples, notably qtdemo.py