### PR TITLE
intel thread building blocks 4.2 update 5

### DIFF
--- a/tbb/build.sh
+++ b/tbb/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ncpus=1
+if test -x /usr/bin/getconf; then
+    ncpus=$(/usr/bin/getconf _NPROCESSORS_ONLN)
+fi
+
+# tested on OSX 10.8.5
+
+make -j$ncpus
+# filter libtbb.dylib ( or .so ), libtbbmalloc.dylib ( or .so )
+cp `find . -name "*lib*" | grep tbb | grep release` $PREFIX/lib
+
+# copy the include files
+cp -r ./include/tbb $PREFIX/include/tbb
+

--- a/tbb/meta.yaml
+++ b/tbb/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: tbb
+  version: 4.2.5
+
+source:
+  fn: tbb42_20140601oss_src.tgz
+  url: https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb42_20140601oss_src.tgz
+  md5: 2968a70d10167310d9890fed7a1c84b1
+
+requirements:
+  build:
+    - python
+
+about:
+  home: http://www.threadingbuildingblocks.org
+  license: GPL v2


### PR DESCRIPTION
builds intel thread building blocks 4.2 update 5 
tested on OSX 10.8.5, should work on linux too, but untested
