### PR TITLE
Move the boost patches into the yaml

### DIFF
--- a/boost/1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch
+++ b/boost/1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch
@@ -1,16 +1,7 @@
-From 9127260dea5092a7fb845cf24758a7cd07156207 Mon Sep 17 00:00:00 2001
-From: Lars Viklund <zao@zao.se>
-Date: Tue, 2 Jul 2013 01:11:29 +0200
-Subject: [PATCH 5/6] Boost.S11n include missing algorithm
-
----
- boost/archive/iterators/transform_width.hpp | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/boost/archive/iterators/transform_width.hpp b/boost/archive/iterators/transform_width.hpp
+diff --git boost/archive/iterators/transform_width.hpp boost/archive/iterators/transform_width.hpp
 index 3562144..f95c675 100644
---- a/boost/archive/iterators/transform_width.hpp
-+++ b/boost/archive/iterators/transform_width.hpp
+--- boost/archive/iterators/transform_width.hpp
++++ boost/archive/iterators/transform_width.hpp
 @@ -30,6 +30,8 @@
  #include <boost/iterator/iterator_adaptor.hpp>
  #include <boost/iterator/iterator_traits.hpp>

--- a/boost/1.55.0_patches/6bb71fdd.diff
+++ b/boost/1.55.0_patches/6bb71fdd.diff
@@ -1,7 +1,7 @@
-diff --git a/include/boost/atomic/detail/cas128strong.hpp b/include/boost/atomic/detail/cas128strong.hpp
+diff --git boost/atomic/detail/cas128strong.hpp boost/atomic/detail/cas128strong.hpp
 index 906c13e..dcb4d7d 100644
---- a/include/boost/atomic/detail/cas128strong.hpp
-+++ b/include/boost/atomic/detail/cas128strong.hpp
+--- boost/atomic/detail/cas128strong.hpp
++++ boost/atomic/detail/cas128strong.hpp
 @@ -196,15 +196,17 @@ class base_atomic<T, void, 16, Sign>
  
  public:

--- a/boost/1.55.0_patches/e4bde20f.diff
+++ b/boost/1.55.0_patches/e4bde20f.diff
@@ -1,7 +1,7 @@
-diff --git a/include/boost/atomic/detail/gcc-atomic.hpp b/include/boost/atomic/detail/gcc-atomic.hpp
+diff --git boost/atomic/detail/gcc-atomic.hpp boost/atomic/detail/gcc-atomic.hpp
 index a130590..4af99a1 100644
---- a/include/boost/atomic/detail/gcc-atomic.hpp
-+++ b/include/boost/atomic/detail/gcc-atomic.hpp
+--- boost/atomic/detail/gcc-atomic.hpp
++++ boost/atomic/detail/gcc-atomic.hpp
 @@ -958,14 +958,16 @@ class base_atomic<T, void, 16, Sign>
  
  public:

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -11,8 +11,6 @@
 # Build dependencies:
 # - bzip2-devel
 
-PATCH_DIR=${RECIPE_DIR}/1.55.0_patches
-
 mkdir -vp ${PREFIX}/bin;
 
 if [ `uname` == Darwin ]; then
@@ -21,15 +19,6 @@ if [ `uname` == Darwin ]; then
   CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
   LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN} "
   LINKFLAGS="${LINKFLAGS} -stdlib=libc++"
-
-  # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
-  # https://github.com/Homebrew/homebrew/issues/27396
-  # https://github.com/Homebrew/homebrew/pull/27436
-  patch -Np2 -i ${PATCH_DIR}/6bb71fdd.diff
-  patch -Np2 -i ${PATCH_DIR}/e4bde20f.diff
-  # Patch boost::serialization for Clang
-  # https://svn.boost.org/trac/boost/ticket/8757
-  patch -Np1 -i ${PATCH_DIR}/0005-Boost.S11n-include-missing-algorithm.patch
 
   B2ARGS="toolset=clang"
 
@@ -53,6 +42,3 @@ else
     install | tee b2.log 2>&1
 fi
 
-#POST_LINK="${PREFIX}/bin/.boost-post-link.sh"
-#cp -v ${RECIPE_DIR}/post-link.sh ${POST_LINK};
-#chmod -v 0755 ${POST_LINK};

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -1,24 +1,24 @@
-
 package:
-    name: boost
-    version: 1.55.0
+  name: boost
+  version: 1.55.0
 
 source:
-    fn: boost_1_55_0.tar.bz2
-    url: http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
+  fn: boost_1_55_0.tar.bz2
+  url: http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
+
+  patches:
+    - 1.55.0_patches/6bb71fdd.diff  [osx]
+    - 1.55.0_patches/e4bde20f.diff  [osx]
+    - 1.55.0_patches/0005-Boost.S11n-include-missing-algorithm.patch  [osx]
 
 build:
-    number: 1
+  number: 1
 
 requirements:
-    build:
-        - python
-    run:
-
-test:
-    imports:
+  build:
+    - python
 
 about:
-    home: http://www.boost.org/
-    license: Boost-1.0
+  home: http://www.boost.org/
+  license: Boost-1.0
 


### PR DESCRIPTION
This moves the boost patches into the yaml to keep them
consistent with other existing packages in the conda
build ecosystem. No other changes are made.
