### PR TITLE
Upgrade to Django 1.7

### DIFF
--- a/django/build.sh
+++ b/django/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+pip install .
 
 # Add more build steps here, if they are necessary.
 

--- a/django/meta.yaml
+++ b/django/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: django
-  version: !!str 1.6.5
+  version: !!str 1.7
 
 source:
-  fn: Django-1.6.6.tar.gz
-  url: https://pypi.python.org/packages/source/D/Django/Django-1.6.6.tar.gz
-  md5: d14fd332f31799fff39acc0c79e8421c
+  fn: Django-1.7.tar.gz
+  url: https://pypi.python.org/packages/source/D/Django/Django-1.7.tar.gz
+  md5: 03edab6828119aa9b32b2252d25eb38d
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -28,9 +28,12 @@ source:
 requirements:
   build:
     - python
+    - pip
+    - setuptools
 
   run:
     - python
+    - setuptools
 
 test:
   # Python imports
@@ -77,7 +80,6 @@ test:
     - django.contrib.gis.utils
     - django.contrib.formtools.wizard.storage
     - django.conf.locale.en_GB
-    - django.conf.locale.fy_NL
     - django.conf.locale.uk
     - django.contrib.gis.gdal.tests
     - django.conf.locale.lv
@@ -194,6 +196,7 @@ test:
   commands:
     # You can put test commands to be run here.  Use this to test that the
     # entry points work.
+    - django-admin --version
     - django-admin.py --version
 
 


### PR DESCRIPTION
Note that I've switched to using pip to install.  For some reason, `python setup.py install` causes `django-admin` and `django-admin.py` to be installed incorrectly.  Switching to pip fixes that, though I'm not sure why.
