### PR TITLE
Updating yt recipe for yt 3.0.1

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 3.0
+  version: 3.0.1
 
 source:
-  fn: yt-3.0.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-3.0.tar.gz
-  md5: c73c9ea79822208a6a373829175ab220
+  fn: yt-3.0.1.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-3.0.1.tar.gz
+  md5: 7983a358aab047ab582aa22bfa0de7fa
 
 build:
   entry_points:


### PR DESCRIPTION
This is a regularly scheduled bugfix release.

This should build and pass the tests on 64 bit python 2.7 on linux, windows, and OS X.  For now we're 64 bit and python2 only.
