### PR TITLE
ncurses: patch libtinfo install prefix to be able to find terminfo db

### DIFF
--- a/ncurses/meta.yaml
+++ b/ncurses/meta.yaml
@@ -8,7 +8,9 @@ source:
   md5: 8cb9c412e5f2d96bc6f459aa8c6282a1
 
 build:
-  number: 3
+  number: 4
+  binary_has_prefix_files:
+    - lib/libtinfo.so.5.9
 
 about:
   home: http://www.gnu.org/software/ncurses/

--- a/ncurses/run_test.py
+++ b/ncurses/run_test.py
@@ -1,0 +1,13 @@
+import curses
+
+if __name__ == '__main__':
+    screen = curses.initscr()
+    try:
+        curses.cbreak()
+        pad = curses.newpad(10, 10)
+        size = screen.getmaxyx()
+        pad.refresh(0, 0, 0, 0, size[0] - 1, size[1] - 1)
+
+    finally:
+        curses.nocbreak()
+        curses.endwin()


### PR DESCRIPTION
This patch fixes a bug in ncurses recipe from #146 that rendered it virtually unusable: terminfo databases were installed at `$PREFIX/share/terminfo` being `$HOME/.conda/_build/share/terminfo`. That bug required me to have a built version of ncurses in build directory at all times.

This patch adds a binary patch for `libtinfo.so` and now ncurses binary seem to work for me and my python recipe without any caveats. I'm unsure about patching the exact sofile, it seems fragile, but OTOH ncurses has a pretty stable ABI and thus this may not be an issue.
