### PR TITLE
Properly fixed CDLL path resolution.

### DIFF
--- a/shapely/osx-geos.patch
+++ b/shapely/osx-geos.patch
@@ -17,7 +17,7 @@ index 20945bb..371be63 100644
 -            # macports
 -            '/opt/local/lib/libgeos_c.dylib',
 -        ]
-+    alt_paths = [os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib')]
-     _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+-    _lgeos = load_dll('geos_c', fallbacks=alt_paths)
++    _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
      free = load_dll('c').free
      free.argtypes = [c_void_p]


### PR DESCRIPTION
Fixes shapely to use the correct libgeos. Relates to https://github.com/Toblerity/Shapely/issues/177 and the library resolution order of find_library.
