### PR TITLE
Updating yt recipe for yt 3.0.2

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 3.0.1
+  version: 3.0.2
 
 source:
-  fn: yt-3.0.1.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-3.0.1.tar.gz
-  md5: 7983a358aab047ab582aa22bfa0de7fa
+  fn: yt-3.0.2.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-3.0.2.tar.gz
+  md5: 4a8c3e8edac14a4da94b79007d3da84a
 
 build:
   entry_points:


### PR DESCRIPTION
This is a regularly scheduled bugfix release.  Still 64 bit only on all three platforms.
