### PR TITLE
Add pims and trackpy

### DIFF
--- a/pims/bld.bat
+++ b/pims/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/pims/build.sh
+++ b/pims/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/pims/build.sh
+++ b/pims/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+echo $SP_DIR
+
+
+$PYTHON setup.py install --single-version-externally-managed --root /

--- a/pims/meta.yaml
+++ b/pims/meta.yaml
@@ -1,0 +1,66 @@
+package:
+  name: pims
+  version: 0.2
+
+source:
+  fn: pims-0.2.tar.gz
+  url: https://pypi.python.org/packages/source/P/PIMS/pims-0.2.tar.gz
+  md5: 3d9f3c47a5e097549c132cbe516e66f6
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pims = pims:main
+    #
+    # Would create an entry point called pims that calls pims.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - numpy
+    - scikit-image  # one of { scikit-image | matplotlib | scipy }
+
+  run:
+    - python
+    - six
+    - numpy
+    - scikit-image  # one of { scikit-image | matplotlib | scipy }
+
+test:
+  # Python imports
+  imports:
+    - pims
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://pims.readthedocs.org
+  license: 3-clause BSD License
+  summary: 'Python particle-tracking toolkit'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/pims/meta.yaml
+++ b/pims/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - numpy
     - scikit-image  # one of { scikit-image | matplotlib | scipy }
     - tifffile
+    - pillow  # optional, but necessary for ipython rich display
 
 test:
   # Python imports

--- a/pims/meta.yaml
+++ b/pims/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pims
-  version: 0.2.2rc2
+  version: 0.2.2
 
 source:
   fn: pims-0.2.2.tar.gz
-  url: https://pypi.python.org/packages/source/P/PIMS/PIMS-0.2.2rc2.tar.gz
-  md5: e49a4993dce60ba507654a88ec44dfd6
+  url: https://pypi.python.org/packages/source/P/PIMS/PIMS-0.2.2.tar.gz
+  md5: ef7d935221df418b2b68b5c5fc721e50
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -39,10 +39,10 @@ requirements:
 
   run:
     - python
-    - six
-    - numpy
+    - six >=1.8
+    - numpy >=1.7
     - scikit-image  # one of { scikit-image | matplotlib | scipy }
-    - tifffile
+    - tifffile >=0.3.1
     - pillow  # optional, but necessary for ipython rich display
 
 test:

--- a/pims/meta.yaml
+++ b/pims/meta.yaml
@@ -1,12 +1,11 @@
 package:
   name: pims
-  version: 0.2.1
+  version: 0.2.2rc2
 
 source:
-  fn: pims-0.2.1.tar.gz
-  url: https://github.com/soft-matter/pims/archive/v0.2.1.tar.gz
-  md5: 871623c381da3840130dfd1588fa46bf
-  sha1: c956b83f8c893a09b25f7576892d022c2d8a6f95
+  fn: pims-0.2.2.tar.gz
+  url: https://pypi.python.org/packages/source/P/PIMS/PIMS-0.2.2rc2.tar.gz
+  md5: e49a4993dce60ba507654a88ec44dfd6
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -36,12 +35,14 @@ requirements:
     - six
     - numpy
     - scikit-image  # one of { scikit-image | matplotlib | scipy }
+    - tifffile
 
   run:
     - python
     - six
     - numpy
     - scikit-image  # one of { scikit-image | matplotlib | scipy }
+    - tifffile
 
 test:
   # Python imports

--- a/pims/meta.yaml
+++ b/pims/meta.yaml
@@ -1,16 +1,17 @@
 package:
   name: pims
-  version: 0.2
+  version: 0.2.1
 
 source:
-  fn: pims-0.2.tar.gz
-  url: https://pypi.python.org/packages/source/P/PIMS/pims-0.2.tar.gz
-  md5: 3d9f3c47a5e097549c132cbe516e66f6
+  fn: pims-0.2.1.tar.gz
+  url: https://github.com/soft-matter/pims/archive/v0.2.1.tar.gz
+  md5: 871623c381da3840130dfd1588fa46bf
+  sha1: c956b83f8c893a09b25f7576892d022c2d8a6f95
 #  patches:
    # List any patch files here
    # - fix.patch
 
-# build:
+build:
   #preserve_egg_dir: True
   #entry_points:
     # Put any entry points (scripts to be generated automatically) here. The
@@ -24,6 +25,9 @@ source:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
   # number: 1
+
+  binary_relocation: true
+
 
 requirements:
   build:
@@ -57,7 +61,7 @@ test:
     # - nose
 
 about:
-  home: http://pims.readthedocs.org
+  home: https://github.com/soft-matter/pims
   license: 3-clause BSD License
   summary: 'Python particle-tracking toolkit'
 

--- a/trackpy/bld.bat
+++ b/trackpy/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/trackpy/build.sh
+++ b/trackpy/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/trackpy/meta.yaml
+++ b/trackpy/meta.yaml
@@ -1,0 +1,73 @@
+package:
+  name: trackpy
+  version: 0.2.1
+
+source:
+  fn: trackpy-0.2.1.tar.gz
+  url: https://pypi.python.org/packages/source/t/trackpy/trackpy-0.2.1.tar.gz#md5=17f7885fc789347cd8d40d7e2df59371 
+  md5: 17f7885fc789347cd8d40d7e2df59371 
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - trackpy = trackpy:main
+    #
+    # Would create an entry point called trackpy that calls trackpy.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - pyyaml
+    - numpy
+    - pandas
+    - scipy
+
+  run:
+    - python
+    - six
+    - pyyaml
+    - numpy
+    - pandas
+    - scipy
+    - matplotlib  # optional but basically essential for use
+    - pims
+
+test:
+  # Python imports
+  imports:
+    - pims
+    - trackpy
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://trackpy.readthedocs.org
+  license: 3-clause BSD License
+  summary: 'Python particle-tracking toolkit'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/trackpy/meta.yaml
+++ b/trackpy/meta.yaml
@@ -1,12 +1,11 @@
 package:
   name: trackpy
-  version: 0.2.3
+  version: 0.2.4rc6
 
 source:
-  fn: trackpy-0.2.3.tar.gz
-  url: https://github.com/soft-matter/trackpy/archive/v0.2.3.tar.gz
-  md5: 07a42c6fa2b49d1ddf17756b36dad3df
-  sha1: 8646aa60e10d4354461be5d432e4c0dde10bd500
+  fn: trackpy-0.2.4rc6.tar.gz
+  url: https://pypi.python.org/packages/source/t/trackpy/trackpy-0.2.4rc6.tar.gz
+  md5: 255eb73f736c3151241ba6286fb71bed
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -53,6 +52,7 @@ requirements:
 test:
   # Python imports
   imports:
+    - tifffile
     - pims
     - trackpy
 

--- a/trackpy/meta.yaml
+++ b/trackpy/meta.yaml
@@ -38,16 +38,16 @@ requirements:
     - matplotlib
 
   run:
-    - matplotlib
     - python
     - six
     - pyyaml
     - numpy
     - pandas
-    - scipy
+    - scipy >=0.12.0
     - matplotlib
     - pims
     - pyyaml
+    - numba 0.12.2
 
 test:
   # Python imports

--- a/trackpy/meta.yaml
+++ b/trackpy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: trackpy
-  version: 0.2.4rc6
+  version: 0.2.4rc7
 
 source:
-  fn: trackpy-0.2.4rc6.tar.gz
-  url: https://pypi.python.org/packages/source/t/trackpy/trackpy-0.2.4rc6.tar.gz
-  md5: 255eb73f736c3151241ba6286fb71bed
+  fn: trackpy-0.2.4rc7.tar.gz
+  url: https://pypi.python.org/packages/source/t/trackpy/trackpy-0.2.4rc7.tar.gz
+  md5: 10cc6969af5856b25da3fbe9ed179b38
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/trackpy/meta.yaml
+++ b/trackpy/meta.yaml
@@ -1,11 +1,12 @@
 package:
   name: trackpy
-  version: 0.2.1
+  version: 0.2.3
 
 source:
-  fn: trackpy-0.2.1.tar.gz
-  url: https://pypi.python.org/packages/source/t/trackpy/trackpy-0.2.1.tar.gz#md5=17f7885fc789347cd8d40d7e2df59371 
-  md5: 17f7885fc789347cd8d40d7e2df59371 
+  fn: trackpy-0.2.3.tar.gz
+  url: https://github.com/soft-matter/trackpy/archive/v0.2.3.tar.gz
+  md5: 07a42c6fa2b49d1ddf17756b36dad3df
+  sha1: 8646aa60e10d4354461be5d432e4c0dde10bd500
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -34,16 +35,20 @@ requirements:
     - numpy
     - pandas
     - scipy
+    - pims
+    - matplotlib
 
   run:
+    - matplotlib
     - python
     - six
     - pyyaml
     - numpy
     - pandas
     - scipy
-    - matplotlib  # optional but basically essential for use
+    - matplotlib
     - pims
+    - pyyaml
 
 test:
   # Python imports


### PR DESCRIPTION
Here are working recipes for [pims](https://github.com/soft-matter/pims) and [trackpy](https://github.com/soft-matter/trackpy). New versions of both of these were uploaded to PyPI on Friday.