### PR TITLE
Adding new recipes for rdflib and isodate (rdflib's depenendecy)

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/isodate/bld.bat
+++ b/isodate/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/isodate/build.sh
+++ b/isodate/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/isodate/meta.yaml
+++ b/isodate/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: isodate
+  version: !!str 0.5.0
+
+source:
+  fn: isodate-0.5.0.tar.gz
+  url: https://pypi.python.org/packages/source/i/isodate/isodate-0.5.0.tar.gz
+  md5: 9a267e9327feb3d021cae26002ba6e0e
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - isodate = isodate:main
+    #
+    # Would create an entry point called isodate that calls isodate.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - isodate
+    - isodate.tests
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://cheeseshop.python.org/pypi/isodate
+  license:  BSD License
+  summary: 'An ISO 8601 date/time/duration parser and formater'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/rdflib/bld.bat
+++ b/rdflib/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/rdflib/build.sh
+++ b/rdflib/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/rdflib/meta.yaml
+++ b/rdflib/meta.yaml
@@ -1,0 +1,82 @@
+package:
+  name: rdflib
+  version: !!str 4.1.2
+
+source:
+  fn: rdflib-4.1.2.tar.gz
+  url: https://pypi.python.org/packages/source/r/rdflib.rdflib-4.1.2.tar.gz
+  md5: a356cf3bdfe1a72d240d151ce5662b84
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  #preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - rdflib = rdflib:main
+    #
+    # Would create an entry point called rdflib that calls rdflib.main()
+
+    - rdfpipe = rdflib.tools.rdfpipe:main
+    - csv2rdf = rdflib.tools.csv2rdf:main
+    - rdf2dot = rdflib.tools.rdf2dot:main
+    - rdfs2dot = rdflib.tools.rdfs2dot:main
+    - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - isodate
+    - pyparsing
+
+  run:
+    - python
+    - isodate
+    - pyparsing
+
+test:
+  # Python imports
+  imports:
+    - rdflib
+    - rdflib.extras
+    - rdflib.plugins
+    - rdflib.plugins.parsers
+    - rdflib.plugins.parsers.pyMicrodata
+    - rdflib.plugins.parsers.pyRdfa
+    - rdflib.plugins.parsers.pyRdfa.extras
+    - rdflib.plugins.parsers.pyRdfa.host
+    - rdflib.plugins.parsers.pyRdfa.rdfs
+    - rdflib.plugins.parsers.pyRdfa.transform
+    - rdflib.plugins.serializers
+    - rdflib.plugins.sparql
+    - rdflib.plugins.sparql.results
+    - rdflib.plugins.stores
+    - rdflib.tools
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    # You can also put a file called run_test.py in the recipe that will be run
+    # at test time.
+    
+  requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/rdflib.rdflib
+  license:  BSD License
+  summary: 'RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/rpy2/meta.yaml
+++ b/rpy2/meta.yaml
@@ -1,17 +1,18 @@
 package:
   name: rpy2
-  version: 2.3.8
+  version: !!str 2.4.4
 
 source:
-  fn: rpy2-2.3.8.tar.gz
-  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.3.8.tar.gz
-  md5: f331120aeeb1b27118d4e3360f2ec45d
+  fn: rpy2-2.4.4.tar.gz
+  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.4.4.tar.gz
+  md5: 58fd357ba922839b65fd67766319b806
 #  patches:
    # List any patch files here
    # - fix.patch
 
 # build:
-  # entry_points:
+  #preserve_egg_dir: True
+  #entry_points:
     # Put any entry points (scripts to be generated automatically) here. The
     # syntax is module:function.  For example
     #
@@ -27,6 +28,7 @@ source:
 requirements:
   build:
     - python
+    - setuptools
 
   run:
     - python
@@ -46,6 +48,23 @@ test:
     - rpy2.robjects.lib.tests
     - rpy2.robjects.tests
 
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
 about:
   home: http://rpy.sourceforge.net
-  license: GNU Affero General Public License v3 or GNU Library or Lesser General Public License (LGPL)
+  license:  GNU General Public License v2 or later (GPLv2+)
+  summary: 'Python interface to the R language (embedded R)'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Two new (and missing) **conda-recipes** plus an updated one.

This PR adds the `rdflib` package and one of its own (missing) dependency, namely the `isodate` package, to the repository, and updates the `rpy2` recipe to the latest version of the package in PyPI.

Packages built and installed from these two recipes have been already pushed to my **binstar** account:
- [https://binstar.org/leriomaggio/isodate]()
- [https://binstar.org/leriomaggio/rdflib]()
- [https://binstar.org/leriomaggio/rpy2]()

Please find below the `conda info` output for additional details on my **Anaconda** Installation:

```
platform : osx-64
conda version : 3.7.0
conda-build version : 1.8.2
python version : 3.4.1.final.0
requests version : 2.4.1
channel URLs : http://repo.continuum.io/pkgs/free/osx-64/
               http://repo.continuum.io/pkgs/pro/osx-64/
```

HTH,
Valerio
