### PR TITLE
Bkreider/postgres

### DIFF
--- a/json-c/build.sh
+++ b/json-c/build.sh
@@ -4,4 +4,5 @@ chmod 755 configure
 ./configure --prefix=$PREFIX
 
 make
+chmod 755 install-sh
 make install

--- a/libiconv/bld.bat
+++ b/libiconv/bld.bat
@@ -1,0 +1,1 @@
+if errorlevel 1 exit 1

--- a/libiconv/build.sh
+++ b/libiconv/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX --disable-debug
+make
+make install

--- a/libiconv/meta.yaml
+++ b/libiconv/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: libiconv
+  version: 1.14 
+
+source:
+  fn: libiconv-1.14.tar.gz
+  url: http://ftpmirror.gnu.org/libiconv/libiconv-1.14.tar.gz
+
+about:
+  home: https://www.gnu.org/software/libiconv/ 
+  license: GPL

--- a/postgis/build.sh
+++ b/postgis/build.sh
@@ -1,3 +1,4 @@
+
 chmod 755 configure
 ./configure \
     --prefix=$PREFIX \

--- a/postgis/meta.yaml
+++ b/postgis/meta.yaml
@@ -9,6 +9,9 @@ source:
 build:
   number: 0
 
+# 
+# OS X needs libiconv
+#
 requirements:
   build:
     - gdal
@@ -17,6 +20,7 @@ requirements:
     - json-c
     - libxml2
     - postgresql
+    - libiconv # [osx]
   run:
     - gdal
     - geos
@@ -24,6 +28,7 @@ requirements:
     - json-c
     - libxml2
     - postgresql
+    - libiconv # [osx]
 
 about:
   home: http://postgis.net

--- a/postgresql-9.3/build.sh
+++ b/postgresql-9.3/build.sh
@@ -1,26 +1,27 @@
 #!/bin/sh
 
-export CFLAGS="-I$PREFIX/include"
+# The libxml2 include is needed because libxslt includes
+# libxml/*.h  which is a subdirectory
+export CFLAGS="-I$PREFIX/include -I$PREFIX/include/libxml2"
 export LDFLAGS="-L$PREFIX/lib -lxml2 -L$PREFIX/lib -lxslt"
 export LDFLAGS_EX="$LDFLAGS -L$PREFIX/lib -lreadline"
 
 if uname | grep Darwin > /dev/null; then
-    # 10.9 appears to have an issue with libxml2; clang/ld isn't respecting
-    # the flags above, and it attempts to link with /usr/lib/libxml2.2.dynlib,
-    # which results in an error and ./configure time.  @Aaron, have you seen
-    # this before?  Can you reproduce the error?
-    configure --prefix=$PREFIX \
+    # The link step is not the problem.  Testing the a.out
+    # binary fails because it finds the wrong dynlib. 
+    DYLD_LIBRARY_PATH=$PREFIX/lib ./configure --prefix=$PREFIX \
+        --disable-debug        \
         --with-readline        \
         --with-python          \
         --with-openssl         \
-        --with-libxml          \
+        --with-libxml2         \
         --with-libxslt
 else
-    configure --prefix=$PREFIX \
+    ./configure --prefix=$PREFIX \
         --with-readline        \
         --with-python          \
         --with-openssl         \
-        --with-libxml          \
+        --with-libxml2         \
         --with-libxslt
 fi
 

--- a/postgresql-9.3/meta.yaml
+++ b/postgresql-9.3/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: http://ftp.postgresql.org/pub/source/v9.3.2/postgresql-9.3.2.tar.bz2
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -16,19 +16,13 @@ requirements:
     - readline
     - libxml2
     - libxslt
-    # 10.9 appears to have an issue with libxml2.
-    #- libxml2   [not osx]
-    #- libxslt   [not osx]
     - zlib
     - system    [linux]
   run:
-    - python
-    - openssl
     - readline
+    - openssl
     - libxml2
     - libxslt
-    #- libxml2   [not osx]
-    #- libxslt   [not osx]
     - zlib
     - system    [linux]
 


### PR DESCRIPTION
@asmeurer I've fixed the postgres build for OSX and PostGIS.  Can someone test and merge my PR?  

@tpn I figured out the Postgres issue on OSX.  It wasn't the Library paths that were wrong during the configure step, it was running the a.out binary during the compilation test.  The dynamic library path wasn't picking up the libxml2 library in $PREFIX. 
