### PR TITLE
bump cloog to 0.18.1

### DIFF
--- a/cloog/meta.yaml
+++ b/cloog/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: cloog
-  version: 0.18.0
+  version: 0.18.1
 
 source:
-  fn: cloog-0.18.0.tar.gz
-  url: http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.0.tar.gz
+  fn: cloog-0.18.1.tar.gz
+  url: http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.1.tar.gz
 
 requirements:
   build:


### PR DESCRIPTION
Avoids impossible to complete dependency in gcc-4.9, which depends on 0.18.1, but would build 0.18.0 from the recipe, over and over again, forever.