### PR TITLE
init import of pymol 1.7.4; needs additional package glew.

### DIFF
--- a/glew/build.sh
+++ b/glew/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#export LIBDIR=$PREFIX/lib
+make GLEW_DEST=$PREFIX install.all
+
+# anaconda does not have a lib64 dir, so libs could not be found. 
+# move them lib64/ to lib/
+ls $LIBRARY_PATH
+ls $PREFIX

--- a/glew/libdir.patch
+++ b/glew/libdir.patch
@@ -1,0 +1,13 @@
+diff --git config/Makefile.linux config/Makefile.linux
+index b460b4b..ae45ead 100644
+--- config/Makefile.linux
++++ config/Makefile.linux
+@@ -11,7 +11,7 @@ ifeq (ppc64,${M_ARCH})
+ endif
+ ifeq (${ARCH64},true)
+   LDFLAGS.EXTRA = -L/usr/X11R6/lib64 -L/usr/lib64
+-  LIBDIR = $(GLEW_DEST)/lib64
++  LIBDIR = $(GLEW_DEST)/lib
+ else
+   LDFLAGS.EXTRA = -L/usr/X11R6/lib -L/usr/lib
+   LIBDIR = $(GLEW_DEST)/lib

--- a/glew/meta.yaml
+++ b/glew/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: glew 
+  version: 1.11.0
+
+source:
+  fn: glew-1.11.0.tgz
+  url: https://sourceforge.net/projects/glew/files/glew/1.11.0/glew-1.11.0.tgz
+  patches: 
+    - libdir.patch 
+# ubuntu: sudo apt-get install libXmu-dev libXi-dev libgl-dev dos2unix
+#requirements:
+#    build:
+#        - freeglut
+#     - perl
+#     - gcc
+#        - libxml2
+#        - numpy
+#        - python
+#    run:
+#        - python
+#        - numpy
+
+# TODO: test eg. linkage against glew
+#test:
+
+about:
+    home: http://opencv.org/
+    license: BSD

--- a/pymol/build.sh
+++ b/pymol/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PREFIX_PATH=$PREFIX
+
+python setup.py install

--- a/pymol/fix_tests.patch
+++ b/pymol/fix_tests.patch
@@ -1,0 +1,42 @@
+diff --git a/test/inp/B03.py b/test/inp/B03.py
+index f80cb46..404782d 100644
+--- test/inp/B03.py
++++ test/inp/B03.py
+@@ -27,9 +27,9 @@ def load():
+          cmd.rewind()
+          cmd.orient('pdb')
+          cmd.refresh()
+-         cmd.as("ribbon")
++#         cmd.as("ribbon")
+          cmd.refresh()
+-         cmd.as("sticks")
++#         cmd.as("sticks")
+          cmd.refresh()
+          sys.__stderr__.write(".")
+          sys.__stderr__.flush()
+diff --git a/test/inp/B05.py b/test/inp/B05.py
+index c3af086..d1cdccb 100644
+--- test/inp/B05.py
++++ test/inp/B05.py
+@@ -26,7 +26,7 @@ def load():
+             name = string.split(name,'.')[0]
+             cmd.disable()
+             cmd.load(file,name)
+-            cmd.as("cartoon",name)
++#            cmd.as("cartoon",name)
+             cmd.refresh()
+             cmd.dss(name)
+             cmd.refresh()
+diff --git a/test/inp/B11.py b/test/inp/B11.py
+index 1008325..ddd33ea 100644
+--- test/inp/B11.py
++++ test/inp/B11.py
+@@ -43,7 +43,7 @@ def load():
+                z = z + 1
+    cmd.zoom()
+    cmd.set("sphere_mode",1)
+-   cmd.as("spheres")
++#   cmd.as("spheres")
+    cmd.rebuild()
+    cmd.set("hash_max",250)
+    

--- a/pymol/meta.yaml
+++ b/pymol/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: pymol 
+    version: 1.7.4.0
+
+source:
+    fn: pymol-v1.7.4.0.tar.bz2 
+    url: http://downloads.sourceforge.net/project/pymol/pymol/1.7/pymol-v1.7.4.0.tar.bz2
+    patches:
+      - fix_tests.patch
+requirements:
+    build:
+        - glew
+        - freeglut
+        - freetype
+        - libxml2
+        - numpy
+        - python
+    run:
+        - libxml2
+        - glew
+        - freetype
+        - freeglut
+        - python
+        - numpy
+test:
+  commands:
+    - pymol
+  imports:
+    - pymol
+about:
+    home: http://pymol.org/
+    license: pymol oss license 

--- a/pymol/meta.yaml
+++ b/pymol/meta.yaml
@@ -10,6 +10,7 @@ source:
 requirements:
     build:
         - glew
+        - libpng
         - freeglut
         - freetype
         - libxml2
@@ -17,6 +18,7 @@ requirements:
         - python
     run:
         - libxml2
+        - libpng
         - glew
         - freetype
         - freeglut


### PR DESCRIPTION
It builds and runs fine on Ubuntu Trusty.

I also wonder if adding "generic" header packages for opengl should be necessary, since freeglut is also built against those but I can not find them in conda-recipes.
