### PR TITLE
update wxpython recipe to 3.0.2.0

### DIFF
--- a/wxpython/build.sh
+++ b/wxpython/build.sh
@@ -5,7 +5,8 @@ mkdir -vp ${PREFIX}/bin;
 ARCH="$(uname 2>/dev/null)"
 
 export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC"
-export CXXLAGS="${CFLAGS}"
+export CXXFLAGS="${CFLAGS} -std=c++11"
+export CPPFLAGS="${CFLAGS} -std=c++11"
 #export CPPFLAGS="-I${PREFIX}/include"
 #export LDFLAGS="-L${PREFIX}/lib64"
 

--- a/wxpython/meta.yaml
+++ b/wxpython/meta.yaml
@@ -1,12 +1,12 @@
 
 package:
     name: wxpython
-    version: 3.0.0.0
+    version: 3.0.2.0
 
 source:
-    fn: wxPython-src-3.0.0.0.tar.bz2
-    url: http://downloads.sourceforge.net/wxpython/wxPython-src-3.0.0.0.tar.bz2
-    sha1: 48451763275cfe4e5bbec49ccd75bc9652cba719
+    fn: wxPython-src-3.0.2.0.tar.bz2
+    url: http://downloads.sourceforge.net/wxpython/wxPython-src-3.0.2.0.tar.bz2
+    sha1: 5053f3fa04f4eb3a9d4bfd762d963deb7fa46866
 
 build:
     number: 2


### PR DESCRIPTION
Tested on Debian Jessie. 

Fixed a typo in the `CXXFLAGS`. Found that I had to set `CPPFLAGS` as well.
Also I needed to set `-std=c++11` in the c++ flags - this might be Debian
specific.

I had to create a symlink for `g++44` because it was getting called in the
build for some reason:

    ln -s /usr/bin/g++ /usr/bin/g++44

I'm not sure why this is. I tried grepping the source for 'g++44' and variants
but couldn't find anything (my g++ is 4.9 and I don't have 4.4 available).

My build is on binstar: https://binstar.org/aaren/wxpython