### PR TITLE
ncurses: use terminfo databases from host system by default

### DIFF
--- a/ncurses/build.sh
+++ b/ncurses/build.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 mkdir $PREFIX/lib
+TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo:$PREFIX/share/terminfo
 
 sh ./configure --prefix=$PREFIX \
-    --without-debug --without-ada --without-manpages \
-    --with-shared --disable-overwrite
-
+    --without-debug \
+    --without-ada \
+    --without-manpages \
+    --with-shared \
+    --disable-overwrite \
+    --disable-termcap \
+    --with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo:$PREFIX/share/terminfo \
+    --with-default-terminfo-dir=/usr/share/terminfo
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make install

--- a/ncurses/meta.yaml
+++ b/ncurses/meta.yaml
@@ -11,7 +11,7 @@ source:
     - fix.patch
 
 build:
-  number: 4 # [linux]
+  number: 5 # [linux]
   detect_binary_files_with_prefix: true
 
 about:


### PR DESCRIPTION
Terminal devices (incl. virtual) are generally provided by host system
and terminfo db should describe their capabilities.  It is more likely
that host system databases will fit the devices provided by the host system
than the databases shipped with conda.

In this respect, my previous effort, #177, is incorrect.
