### PR TITLE
Add pydot recipe and compile with pyparsing 2.x

### DIFF
--- a/pydot/bld.bat
+++ b/pydot/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/pydot/build.patch
+++ b/pydot/build.patch
@@ -1,0 +1,15 @@
+diff --git a/dot_parser.py b/dot_parser.py
+index dedd61a..8a7ff8b 100644
+--- dot_parser.py
++++ dot_parser.py
+@@ -25,7 +25,9 @@ from pyparsing import __version__ as pyparsing_version
+ from pyparsing import ( nestedExpr, Literal, CaselessLiteral, Word, Upcase, OneOrMore, ZeroOrMore,
+     Forward, NotAny, delimitedList, oneOf, Group, Optional, Combine, alphas, nums,
+     restOfLine, cStyleComment, nums, alphanums, printables, empty, quotedString,
+-    ParseException, ParseResults, CharsNotIn, _noncomma, dblQuotedString, QuotedString, ParserElement )
++    ParseException, ParseResults, CharsNotIn, dblQuotedString, QuotedString, ParserElement )
++    
++_noncomma = "".join( [ c for c in printables if c != "," ] )
+ 
+ 
+ class P_AttrList:

--- a/pydot/build.sh
+++ b/pydot/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/pydot/meta.yaml
+++ b/pydot/meta.yaml
@@ -1,0 +1,51 @@
+package:
+  name: pydot
+  version: !!str 1.0.28
+
+source:
+  fn: pydot-1.0.28.tar.gz
+  url: http://pydot.googlecode.com/files/pydot-1.0.28.tar.gz
+  md5: c0a7a027176a62c412fd0f54951af692
+  patches:
+   # List any patch files here
+    - build.patch
+
+build:
+  preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pydot = pydot:main
+    #
+    # Would create an entry point called pydot that calls pydot.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 1
+
+requirements:
+  build:
+    - python
+    - pyparsing
+    - setuptools
+
+  run:
+    - python
+    - pyparsing
+    - setuptools
+
+test:
+  # Python imports
+  imports:
+    - pydot
+
+about:
+  home: http://code.google.com/p/pydot/
+  license: MIT License
+  summary: "Python interface to Graphviz's Dot"
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Pyparsing v2.x is the default version installed in anaconda but pydot by default depends on pyparsing v1.5.X

The patch is based on http://stackoverflow.com/a/18547813/4385312