### PR TITLE
Fix cvxopt recipe for OS X

### DIFF
--- a/cvxopt/bld.bat
+++ b/cvxopt/bld.bat
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-python setup.py install
-if errorlevel 1 exit 1
-=======
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1
 
@@ -10,4 +6,3 @@ if errorlevel 1 exit 1
 :: See
 :: http://docs.continuum.io/conda/build.html
 :: for a list of environment variables that are set during the build process.
->>>>>>> master

--- a/cvxopt/meta.yaml
+++ b/cvxopt/meta.yaml
@@ -11,12 +11,12 @@ build:
 
 requirements:
     build:
-        - atlas
+        - atlas # [linux]
         - python
         - distribute
 
     run:
-        - atlas
+        - atlas # [linux]
         - python
 
 test:

--- a/cvxopt/meta.yaml
+++ b/cvxopt/meta.yaml
@@ -1,10 +1,10 @@
 package:
     name: cvxopt
-    version: 1.1.6
+    version: 1.1.7
 
 source:
     git_url: https://github.com/cvxopt/cvxopt.git
-    git_tag: 1.1.6
+    git_tag: 1.1.7
 
 build:
     number: 1


### PR DESCRIPTION
@asmeurer The atlas package is actually unnecessary for OS X, as LAPACK and BLAS are packaged with the OS. Here's the ldd-equivalent output:

```
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/amd.so:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/base.so:
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/blas.so:
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/cholmod.so:
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/lapack.so:
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/misc_solvers.so:
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
/Users/chris/anaconda/lib/python2.7/site-packages/cvxopt/umfpack.so:
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libLAPACK.dylib (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 283.0.0)
```

Also, I realize this isn't the repo backing the anaconda builds - but I'd like to get this fixed in the official channel, so please let me know if you happen to know who the appropriate person to contact is.