### PR TITLE
Use a tagged version of ggplot (from pypi) instead of 'master'

### DIFF
--- a/ggplot/meta.yaml
+++ b/ggplot/meta.yaml
@@ -1,11 +1,12 @@
 
 package:
     name: ggplot
-    version: "master"
+    version: !!str 0.6.5
 
 source:
-    git_url: https://github.com/yhat/ggplot
-    git_tag: "master"
+    fn: ggplot-0.6.5.tar.gz
+    url: https://pypi.python.org/packages/source/g/ggplot/ggplot-0.6.5.tar.gz
+    md5: c825f9ca48bc9b12c2e2517c7f8b9538
 
 build:
     number: 0


### PR DESCRIPTION
I think this will make it easier to release updated recipes
