### PR TITLE
H5py updates and fixes

### DIFF
--- a/h5py/bld.bat
+++ b/h5py/bld.bat
@@ -1,10 +1,15 @@
-REM h5py expects hdf5dll18.lib, so make a copy of the hdf5 .lib
-copy %LIBRARY_LIB%\hdf5.lib %PREFIX%\libs\hdf5dll18.lib
-copy %LIBRARY_LIB%\hdf5_hl.lib %PREFIX%\libs\hdf5_hldll.lib
+REM h5py expects hdf5 libraries to have h5py prefix so make a copy of the hdf5 .lib
+REM see https://github.com/h5py/h5py/blob/master/windows/cacheinit.cmake#L14
 
+copy %LIBRARY_LIB%\libhdf5.lib %LIBRARY_LIB%\h5py_hdf5.lib
+copy %LIBRARY_LIB%\libhdf5_hl.lib %LIBRARY_LIB%\h5py_hdf5_hl.lib
+
+REM h5py autodection fails on Windows so set directory and version
 set HDF5_DIR=%LIBRARY_PREFIX%
+set HDF5_VERSION=1.8.13
 
 python setup.py install
 if errorlevel 1 exit 1
 
-del %PREFIX%\libs\hdf5*
+del %LIBRARY_LIB%\h5py_hdf5.lib
+del %LIBRARY_LIB%\h5py_hdf5_hl.lib

--- a/h5py/meta.yaml
+++ b/h5py/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: h5py
-  version: 2.3.0
+  version: 2.4.0
 
 source:
-  fn: h5py-2.3.0.tar.gz
-  url: https://github.com/h5py/h5py/archive/2.3.0.tar.gz
-  md5: 2dca39fb2ff6e70824487201e1d1fb84
+  fn: h5py-2.4.0.tar.gz
+  url: https://github.com/h5py/h5py/archive/2.4.0.tar.gz
+  md5: b0fb53487c33db87a5b8cd343c2cf43a
 
 requirements:
   build:

--- a/h5py/run_test.py
+++ b/h5py/run_test.py
@@ -1,21 +1,2 @@
 import h5py
-import h5py._conv
-import h5py._errors
-import h5py._objects
-import h5py._proxy
-import h5py.defs
-import h5py.h5
-import h5py.h5a
-import h5py.h5d
-import h5py.h5f
-import h5py.h5fd
-import h5py.h5g
-import h5py.h5i
-import h5py.h5l
-import h5py.h5o
-import h5py.h5p
-import h5py.h5r
-import h5py.h5s
-import h5py.h5t
-import h5py.h5z
-import h5py.utils
+h5py.run_tests()


### PR DESCRIPTION
- rolls to h5py v2.4.0
- fixes Windows build script
- call h5py test suite
