### PR TITLE
Fix SimpleITK build script for windows

### DIFF
--- a/simpleitk/bld.bat
+++ b/simpleitk/bld.bat
@@ -1,15 +1,18 @@
-mkdir C:\bld
-cd C:\bld
+mkdir C:\b
+cd C:\b
 
 if "%ARCH%" == "32" set "CMAKE_GENERATOR=Visual Studio 9 2008"
-if "%ARCH%" == "64" set "CMAKE_GENERATOR=Visual Studio 9 Win64"
+if "%ARCH%" == "64" set "CMAKE_GENERATOR=Visual Studio 9 2008 Win64"
+
+REM Remove dot from PY_VER for use in library name
+set MY_PY_VER=%PY_VER:.=%
 
 REM Configure Step
 cmake -G "%CMAKE_GENERATOR%" ^
     -D SimpleITK_BUILD_DISTRIBUTE:BOOL=ON ^
-    -D SimpleITK_BUILD_STRIP:BOOL=ON ^
     -D BUILD_SHARED_LIBS:BOOL=OFF ^
     -D BUILD_TESTING:BOOL=OFF ^
+    -D BUILD_EXAMPLES:BOOL=OFF ^
     -D WRAP_CSHARP:BOOL=OFF ^
     -D WRAP_LUA:BOOL=OFF ^
     -D WRAP_PYTHON:BOOL=ON ^
@@ -18,14 +21,14 @@ cmake -G "%CMAKE_GENERATOR%" ^
     -D WRAP_TCL:BOOL=OFF ^
     -D WRAP_R:BOOL=OFF ^
     -D WRAP_RUBY:BOOL=OFF ^
-    -D ITK_USE_SYSTEM_JPEG:BOOL=ON ^
-    -D ITK_USE_SYSTEM_PNG:BOOL=ON ^
-    -D ITK_USE_SYSTEM_TIFF:BOOL=ON ^
-    -D ITK_USE_SYSTEM_ZLIB:BOOL=ON ^
+    -D ITK_USE_SYSTEM_JPEG:BOOL=OFF ^
+    -D ITK_USE_SYSTEM_PNG:BOOL=OFF ^
+    -D ITK_USE_SYSTEM_TIFF:BOOL=OFF ^
+    -D ITK_USE_SYSTEM_ZLIB:BOOL=OFF ^
     -D "CMAKE_SYSTEM_PREFIX_PATH:PATH=%PREFIX%/Library" ^
     -D "PYTHON_EXECUTABLE:FILEPATH=%PYTHON%" ^
     -D "PYTHON_INCLUDE_DIR:PATH=%PREFIX%/include" ^
-    -D "PYTHON_LIBRARY:FILEPATH=%PREFIX%/lib/libpython%PY_VER%.lib" ^
+    -D "PYTHON_LIBRARY:FILEPATH=%PREFIX%/libs/python%MY_PY_VER%.lib" ^
     "%SRC_DIR%/SuperBuild"
 
 if errorlevel 1 exit 1
@@ -38,5 +41,5 @@ REM Install step
 REM cmake --build  . --config Release --target INSTALL
 if errorlevel 1 exit 1
 
-cd %BUILD_DIR%\SimpleITK-build\Wrapping
+cd SimpleITK-build\Wrapping
 %PYTHON% PythonPackage\setup.py install

--- a/simpleitk/meta.yaml
+++ b/simpleitk/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: simpleitk
-  version: "0.8.1"
+  version: "0.9.0b01"
 
 source:
   git_url: http://itk.org/SimpleITK.git
-  git_tag: 260e265160887fff62fd17f4a717fdc0150cba11
+  git_tag: v0.9b01
 
 requirements:
   build:

--- a/simpleitk/meta.yaml
+++ b/simpleitk/meta.yaml
@@ -4,23 +4,23 @@ package:
 
 source:
   git_url: http://itk.org/SimpleITK.git
-  git_tag:  v0.8.1
+  git_tag: 260e265160887fff62fd17f4a717fdc0150cba11
 
 requirements:
   build:
     - python
     - cmake      # [not win]
-    - libtiff
-    - libpng
-    - jpeg
-    - zlib
+    - libtiff    # [not win]
+    - libpng     # [not win]
+    - jpeg       # [not win]
+    - zlib       # [not win]
     - setuptools
   run:
     - python
-    - libtiff
-    - libpng
-    - jpeg
-    - zlib
+    - libtiff    # [not win]
+    - libpng     # [not win]
+    - jpeg       # [not win]
+    - zlib       # [not win]
 
 test:
   imports:


### PR DESCRIPTION
Update SimpleITK hash, with CMake build fixes for EXAMPLES, and an escape
sequence issue.

Use internal third party libraries on windows since depencent dll aren't automatically
include in the path at run-time. See:
https://groups.google.com/a/continuum.io/forum/#!topic/conda/wnRbABPq4hE

Use CONDA_PY for python version, as PY_VER is not being defined.