### PR TITLE
Updates HDF4 to version 4.2.10

### DIFF
--- a/hdf4/max_files.patch
+++ b/hdf4/max_files.patch
@@ -1,6 +1,6 @@
-diff -rupN hdf-4.2.10/hdf/src/hlimits.h new/hdf/src/hlimits.h
---- hdf-4.2.10/hdf/src/hlimits.h	2014-02-10 02:28:49.000000000 +0000
-+++ new/hdf/src/hlimits.h	2014-09-02 14:07:48.015297738 +0100
+diff -rupN hdf-4.2.11/hdf/src/hlimits.h new/hdf/src/hlimits.h
+--- hdf-4.2.11/hdf/src/hlimits.h	2014-02-10 02:28:49.000000000 +0000
++++ hdf/src/hlimits.h	2014-09-02 14:07:48.015297738 +0100
 @@ -88,7 +88,7 @@
  /* ------------------------- Constants for hfile.c --------------------- */
  /* Maximum number of files (number of slots for file records) */

--- a/hdf4/max_files.patch
+++ b/hdf4/max_files.patch
@@ -1,0 +1,12 @@
+diff -rupN hdf-4.2.10/hdf/src/hlimits.h new/hdf/src/hlimits.h
+--- hdf-4.2.10/hdf/src/hlimits.h	2014-02-10 02:28:49.000000000 +0000
++++ new/hdf/src/hlimits.h	2014-09-02 14:07:48.015297738 +0100
+@@ -88,7 +88,7 @@
+ /* ------------------------- Constants for hfile.c --------------------- */
+ /* Maximum number of files (number of slots for file records) */
+ #ifndef MAX_FILE
+-#   define MAX_FILE   32
++#   define MAX_FILE   2048
+ #endif /* MAX_FILE */
+ 
+ /* Maximum length of external filename(s) (used in hextelt.c) */

--- a/hdf4/meta.yaml
+++ b/hdf4/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: hdf4
-  version: 4.2.10
+  version: 4.2.11
 
 source:
-  fn: hdf-4.2.10.tar.bz2
-  url: http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.10.tar.bz2
-  md5: bf26b3caaf3c0090965c8995578375bd
+  fn: hdf-4.2.11.tar.bz2
+  url: http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.11.tar.bz2
+  md5: 192a0320ef06f657523c2efaee0ccdcf
   patches: 
     - max_files.patch
 requirements:

--- a/hdf4/meta.yaml
+++ b/hdf4/meta.yaml
@@ -1,23 +1,23 @@
 package:
-    name: hdf4
-    version: 4.2.9
+  name: hdf4
+  version: 4.2.10
 
 source:
-    fn: hdf-4.2.9.tar.bz2
-    url: http://www.hdfgroup.org/ftp/HDF/releases/HDF4.2.9/src/hdf-4.2.9.tar.bz2
-    md5: c268a703f334ee4987fa710a0de9b9fc
-
-build:
-    number: 0
-
+  fn: hdf-4.2.10.tar.bz2
+  url: http://www.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.10.tar.bz2
+  md5: bf26b3caaf3c0090965c8995578375bd
+  patches: 
+    - max_files.patch
 requirements:
-    build:
-
-    run:
-
-test:
-    imports:
+  build:
+    - python
+    - jpeg
+    - zlib
+  run:
+    - python
+    - jpeg
+    - zlib
 
 about:
-    home: http://www.hdfgroup.org/HDF4/
-    license: BSD-style (http://www.hdfgroup.org/ftp/HDF/current/src/unpacked/COPYING)
+  home: http://www.hdfgroup.org
+  license: BSD-stype


### PR DESCRIPTION
It is tested on Linux on X86..._64, and works file. **Additionally**, it introduces a patch to **increase the maximum allowed simultaneously opened files** from 32 to 2048. This patch is beningn, in the sense that we have deployed the binaries on many systems where other users use the library and have found no side effects. This allows other packages like GDAL to exploit the usefulness of having many possible HDF4 files opened simultaneously (e.g. see [here](http://www.gdal.org/frmt_hdf4.html)])