### PR TITLE
Updates GDAL to 1.11.1, and adds HDF4, HDF5, LibnetCDF formats, an...

### DIFF
--- a/gdal/build.sh
+++ b/gdal/build.sh
@@ -6,9 +6,8 @@
 --with-hdf4=$PREFIX \
 --with-netcdf=$PREFIX \
 --with-xerces=$PREFIX \
---with-sqlite=$PREFIX \
+--with-sqlite3=$PREFIX \
 --without-pam \
---with-python \
 --disable-rpath
 
 make 

--- a/gdal/build.sh
+++ b/gdal/build.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
+./configure --with-python --prefix=$PREFIX \
+--with-geos=$PREFIX/bin/geos-config \
+--with-static-proj4=$PREFIX \
+--with-hdf5=$PREFIX \
+--with-hdf4=$PREFIX \
+--with-netcdf=$PREFIX \
+--with-xerces=$PREFIX \
+--with-sqlite=$PREFIX \
+--without-pam \
+--with-python \
+--disable-rpath
 
-bash configure --with-python --prefix=$PREFIX
-make
+make 
 make install
 
-rm -rf $PREFIX/share
+# Copy data files 
+mkdir -p $PREFIX/share/gdal/
+cp data/*csv $PREFIX/share/gdal/
+cp data/*wkt $PREFIX/share/gdal/
+
+

--- a/gdal/build.sh
+++ b/gdal/build.sh
@@ -7,6 +7,7 @@
 --with-netcdf=$PREFIX \
 --with-xerces=$PREFIX \
 --with-sqlite3=$PREFIX \
+--with-curl=$PREFIX/bin/curl-config \
 --without-pam \
 --disable-rpath
 

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -1,18 +1,29 @@
 package:
   name: gdal
-  version: 1.10.1
+  version: 1.11.1
 
 source:
-  fn: gdal-1.10.1.tar.gz
-  url: http://download.osgeo.org/gdal/1.10.1/gdal-1.10.1.tar.gz
-  md5: 86b2c71a910d826a7fe6ebb43a532fb7
+  fn: gdal-1.11.1.tar.gz
+  url: http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz
+  md5: 7555f55855f613be49e6508eed0ac3fa
 
 requirements:
   build:
     - python
+    - hdf4
+    - hdf5 
+    - numpy >=1.9
+    - geos
+    - proj4
+    - curl
   run:
     - python
-
+    - hdf5
+    - hdf4
+    - numpy >=1.9
+    - geos
+    - proj4
+    - curl
 test:
   files:
     - os1_hw.py

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: gdal
-  version: 1.11.1
+  version: 1.11.2
 
 source:
-  fn: gdal-1.11.1.tar.gz
-  url: http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz
-  md5: 7555f55855f613be49e6508eed0ac3fa
+  fn: gdal-1.11.2.tar.gz
+  url: http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
+  md5: 866a46f72b1feadd60310206439c1a76
 
 requirements:
   build:

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - geos
     - proj4
     - curl
+    - libnetcdf
   run:
     - python
     - hdf5
@@ -24,6 +25,7 @@ requirements:
     - geos
     - proj4
     - curl
+    - libnetcdf
 test:
   files:
     - os1_hw.py

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - python
     - hdf4
     - hdf5 
-    - numpy >=1.9
+    - numpy 
     - geos
     - proj4
     - curl
@@ -20,7 +20,7 @@ requirements:
     - python
     - hdf5
     - hdf4
-    - numpy >=1.9
+    - numpy
     - geos
     - proj4
     - curl

--- a/gdal/run_test.py
+++ b/gdal/run_test.py
@@ -7,9 +7,28 @@ import gdal
 import gdalconst
 import ogr
 import osr
+import urllib2
 
+print( "OGR Vector drivers")
+print("==================")
 cnt = ogr.GetDriverCount()
+for i in range(cnt):
+    print(ogr.GetDriver(i).GetName())
+
+print ("GDAL Raster drivers")
+print ("===================")
+cnt = gdal.GetDriverCount()
 for i in xrange(cnt):
-    print ogr.GetDriver(i).GetName()
+    print (gdal.GetDriver(i).LongName)
+
+print ("Total number of vector drivers: %d" % ogr.GetDriverCount())
+print ("Total number of vector drivers: %d" % gdal.GetDriverCount())
+
+print ("Testing opening a MODIS file...")
+fp = open ( "MCD45A1.A2006213.h17v04.051.2013060204001.hdf", 'w')
+fp.write ( urllib2.urlopen("http://e4ftl01.cr.usgs.gov/MOTA/MCD45A1.051/2006.08.01/MCD45A1.A2006213.h17v04.051.2013060204001.hdf").read() )
+fp.close()
+g = gdal.Open ( "MCD45A1.A2006213.h17v04.051.2013060204001.hdf" )
+print ( g.GetSubDatasets() )
 
 import os1_hw

--- a/gdal/run_test.py
+++ b/gdal/run_test.py
@@ -9,7 +9,7 @@ import ogr
 import osr
 import urllib2
 
-print( "OGR Vector drivers")
+print("OGR Vector drivers")
 print("==================")
 cnt = ogr.GetDriverCount()
 for i in range(cnt):
@@ -25,10 +25,10 @@ print ("Total number of vector drivers: %d" % ogr.GetDriverCount())
 print ("Total number of vector drivers: %d" % gdal.GetDriverCount())
 
 print ("Testing opening a MODIS file...")
-fp = open ( "MCD45A1.A2006213.h17v04.051.2013060204001.hdf", 'w')
+fp = open ("MCD45A1.A2006213.h17v04.051.2013060204001.hdf", 'w')
 fp.write ( urllib2.urlopen("http://e4ftl01.cr.usgs.gov/MOTA/MCD45A1.051/2006.08.01/MCD45A1.A2006213.h17v04.051.2013060204001.hdf").read() )
 fp.close()
-g = gdal.Open ( "MCD45A1.A2006213.h17v04.051.2013060204001.hdf" )
-print ( g.GetSubDatasets() )
+g = gdal.Open ("MCD45A1.A2006213.h17v04.051.2013060204001.hdf")
+print (g.GetSubDatasets())
 
 import os1_hw


### PR DESCRIPTION
Updated GDAL to 1.11.1, but also added HDF4, HDF5, LibnetCDF formats, and dependencies. Added a short script to test opening MODIS HDF files (a format often requested by users), as well as listing the supported formats, both for vector and raster. Only tested on Linux X86, should be easy to extend to MacOSX. This patch would make the package extremely useful for users of remote sensing data, as it now includes a wealth of often-used formats.
