### PR TITLE
Update qt5, pyqt5, and sip. Also fixes qt5 build on unix

### DIFF
--- a/pyqt5/meta.yaml
+++ b/pyqt5/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: pyqt5
-  version: 5.4
+  version: 5.4.1
 
 source:
-  fn: PyQt-gpl-5.4.zip # [win]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4/PyQt-gpl-5.4.zip # [win]
-  sha1: 3d3967025ca4019356c0b2a81e046ff08ca07d9b # [win]
-  fn: PyQt-gpl-5.4.tar.gz # [unix]
-  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4/PyQt-gpl-5.4.tar.gz # [unix]
-  sha1: 057e6b32c43e673e79f876fb9b6f33d3072edfc2 # [unix]
+  fn: PyQt-gpl-5.4.1.zip # [win]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4.1/PyQt-gpl-5.4.1.zip # [win]
+  sha1: 05d1780490af247202b107dff87c4fc57d27fb2f # [win]
+  fn: PyQt-gpl-5.4.1.tar.gz # [unix]
+  url: http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.4.1/PyQt-gpl-5.4.1.tar.gz # [unix]
+  sha1: 0662379b66da422dfcbb0ca46df9d41208e859f4 # [unix]
 
   #patches: # [osx]
   #  - configure.patch # [osx] may not be required for >5.3.2
@@ -16,14 +16,14 @@ source:
 requirements:
   build:
     - python
-    - qt5 >=5.4.0
-    - sip >=4.16.5
+    - qt5 >=5.4.1
+    - sip >=4.16.7
     - jom # [win]
 
   run:
     - python
-    - qt5 >=5.4.0
-    - sip >=4.16.5
+    - qt5 >=5.4.1
+    - sip >=4.16.7
 
 test:
   imports:

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -35,7 +35,6 @@ chmod +x configure
             -opensource \
             -confirm-license \
             -shared \
-            -process \
             -nomake examples \
             -nomake tests \
             -fontconfig \

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: qt5
-  version: 5.4.0
+  version: 5.4.1
 
 source:
-  fn: qt-everywhere-opensource-src-5.4.0.tar.gz # [unix]
-  url: http://download.qt-project.org/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.tar.gz # [unix]
-  sha1: 06a510e1019f3d42d122b89b912332e804da41e1 # [unix]
-  fn: qt-everywhere-opensource-src-5.4.0.zip # [win]
-  url: http://download.qt-project.org/official_releases/qt/5.4/5.4.0/single/qt-everywhere-opensource-src-5.4.0.zip # [win]
-  sha1: d098e27e441f6d806c0e56c65f40c57931754acc # [win]
+  fn: qt-everywhere-opensource-src-5.4.1.tar.gz # [unix]
+  url: http://download.qt.io/official_releases/qt/5.4/5.4.1/single/qt-everywhere-opensource-src-5.4.1.tar.gz # [unix]
+  sha1: e696b353a80ad53bcfd9535e744b5cd3246f5fd1 # [unix]
+  fn: qt-everywhere-opensource-src-5.4.1.zip # [win]
+  url: http://download.qt.io/official_releases/qt/5.4/5.4.1/single/qt-everywhere-opensource-src-5.4.1.zip # [win]
+  sha1: 40ade5606b42b1cfe9522e04323d2d6e2f3365c0 # [win]
 
 build:
   detect_binary_files_with_prefix: true

--- a/sip/meta.yaml
+++ b/sip/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: sip
-  version: 4.16.5
+  version: 4.16.7
 
 source:
-  fn: sip-4.16.5.tar.gz # [unix]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.tar.gz # [unix]
-  sha1: d5d7b6765de8634eccf48a250dbd915f01b2a771 # [unix]
-  fn: sip-4.16.5.zip # [win]
-  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.5/sip-4.16.5.zip # [win]
-  sha1: fa6c055a3db805218bd962a9fb182aa0bf91f95e # [win]
+  fn: sip-4.16.7.tar.gz # [unix]
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.7/sip-4.16.7.tar.gz # [unix]
+  sha1: ec467c1ca9f9ead16be869eccc2e7cae72750d56 # [unix]
+  fn: sip-4.16.7.zip # [win]
+  url: http://sourceforge.net/projects/pyqt/files/sip/sip-4.16.7/sip-4.16.7.zip # [win]
+  sha1: 52e51893ff5deb9d41efaefc63e2233459680b4c # [win]
 
 requirements:
   build:


### PR DESCRIPTION
I have done the following to these packages:
* Update qt5 to version 5.4.1
* Update pyqt5 to version 5.4.1
* Update sip to version 4.16.7
* Fix the qt5 build on unix by removing the Windows-only `-process` flag. This was probably just copy-and-pasted on accident.

I have tested the resulting pyqt5 package by creating a simple QtWidgets view and also a simple QtQuick application. Therefore, I am confident that the main modules like QtCore, QtWidgets, QtGui, and QtQuick work.

I made builds of all three of these packages on Arch Linux and uploaded them to binstar (my username is jdreaver there too). Here is a [link to the pyqt5 linux file download page](https://binstar.org/jdreaver/pyqt5/files).

I haven't tested these updates on Windows. I did update the SHA1 sums of the source zip files though. Of course, more people should probably try this recipe out on different Linux distributions and on OSX too :)