### PR TITLE
[WIP] Adding Qt5 Linux dependencies

### DIFF
--- a/bison/build.sh
+++ b/bison/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/bison/meta.yaml
+++ b/bison/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: bison
+  version: 3.0.4
+
+source:
+  fn: bison-3.0.4.tar.gz # [linux]
+  url: http://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz # [linux]
+  md5: a586e11cd4aff49c3ff6d3b6a4c9ccf8 # [linux]
+
+about:
+    home: https://www.gnu.org/software/bison/
+    license: GPL3
+
+requirements:
+  build:
+    - m4 # [linux]

--- a/bison/meta.yaml
+++ b/bison/meta.yaml
@@ -14,3 +14,6 @@ about:
 requirements:
   build:
     - m4 # [linux]
+  
+  run:
+    - m4 # [linux]

--- a/damageproto/build.sh
+++ b/damageproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/damageproto/meta.yaml
+++ b/damageproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: damageproto
+  version: 1.2.1
+
+source:
+  fn: damageproto-1.2.1.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/damageproto-1.2.1.tar.bz2 # [linux]
+  md5: 998e5904764b82642cc63d97b4ba9e95 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/dri2proto/build.sh
+++ b/dri2proto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/dri2proto/meta.yaml
+++ b/dri2proto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: dri2proto
+  version: 2.8
+
+source:
+  fn: dri2proto-2.8.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/dri2proto-2.8.tar.gz # [linux]
+  md5: 19ea18f63d8ae8053c9fa84b60365b77 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/dri3proto/build.sh
+++ b/dri3proto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/dri3proto/meta.yaml
+++ b/dri3proto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: dri3proto
+  version: 1.0
+
+source:
+  fn: dri3proto-1.0.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/dri3proto-1.0.tar.gz # [linux]
+  md5: 25e84a49a076862277ee12aebd49ff5f # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/ed/build.sh
+++ b/ed/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/ed/meta.yaml
+++ b/ed/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: ed
+  version: 1.9
+
+source:
+  fn: ed-1.9.tar.gz # [linux]
+  url: http://ftp.gnu.org/gnu/ed/ed-1.9.tar.gz # [linux]
+  md5: 565b6d1d5a9a8816b9b304fc4ed9405d # [linux]
+
+about:
+    home: https://www.gnu.org/software/ed/
+    license: GPL3
+
+test:
+  commands:
+    - ed --help

--- a/fixesproto/build.sh
+++ b/fixesproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/fixesproto/meta.yaml
+++ b/fixesproto/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: fixesproto
+  version: 5.0
+
+source:
+  fn: fixesproto-5.0.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/fixesproto-5.0.tar.bz2 # [linux]
+  md5: e7431ab84d37b2678af71e29355e101d # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - xextproto # [linux]
+  run:
+    - xextproto # [linux]

--- a/flex/build.sh
+++ b/flex/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/flex/meta.yaml
+++ b/flex/meta.yaml
@@ -14,3 +14,6 @@ about:
 requirements:
   build:
     - m4 # [linux]
+
+  run:
+    - m4 # [linux]

--- a/flex/meta.yaml
+++ b/flex/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: flex
+  version: 2.5.39
+
+source:
+  fn: flex-2.5.39.tar.gz # [linux]
+  url: http://sourceforge.net/projects/flex/files/flex-2.5.39.tar.gz # [linux]
+  md5: e133e9ead8ec0a58d81166b461244fde # [linux]
+
+about:
+    home: http://flex.sourceforge.net/
+    license: BSD
+
+requirements:
+  build:
+    - m4 # [linux]

--- a/glproto/build.sh
+++ b/glproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/glproto/meta.yaml
+++ b/glproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: glproto
+  version: 1.4.17
+
+source:
+  fn: glproto-1.4.17.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/glproto-1.4.17.tar.bz2 # [linux]
+  md5: 5565f1b0facf4a59c2778229c1f70d10 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/gperf/build.sh
+++ b/gperf/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/gperf/meta.yaml
+++ b/gperf/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: gperf
+  version: 3.0.4
+
+source:
+  fn: gperf-3.0.4.tar.gz # [linux]
+  url: http://ftp.gnu.org/pub/gnu/gperf/gperf-3.0.4.tar.gz # [linux]
+  md5: c1f1db32fb6598d6a93e6e88796a8632 # [linux]
+
+about:
+    home: https://www.gnu.org/software/gperf/
+    license: GPL3

--- a/gstreamer/build.sh
+++ b/gstreamer/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# gstreamer expects libffi.la to be in lib64 for some reason.
+mkdir $PREFIX/lib64
+cp -r $LIBRARY_PATH/libffi* $PREFIX/lib64
+ls $PREFIX/lib64
+
+# The datarootdir option places the docs into a temp folder that won't
+# be included in the package (it is about 12MB).
+./configure --disable-examples --prefix="$PREFIX" --datarootdir=`pwd`/tmpshare
+make
+make install
+
+# Remove the created lib64 directory
+rm -rf $PREFIX/lib64

--- a/gstreamer/meta.yaml
+++ b/gstreamer/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: gstreamer
+  version: 1.4.5
+
+source:
+  fn: gstreamer-1.4.5.tar.xz # [linux]
+  url: http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.4.5.tar.xz # [linux]
+  md5: 88a9289c64a4950ebb4f544980234289 # [linux]
+
+about:
+    home: http://gstreamer.freedesktop.org/
+    license: LGPL
+
+requirements:
+  build:
+    - bison # [linux]
+    - flex # [linux]
+    - glib # [linux]
+  
+  run:
+    - glib # [linux]

--- a/inputproto/build.sh
+++ b/inputproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/inputproto/meta.yaml
+++ b/inputproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: inputproto
+  version: 2.3
+
+source:
+  fn: inputproto-2.3.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/inputproto-2.3.tar.bz2 # [linux]
+  md5: 94db391e60044e140c9854203d080654 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/libdrm/build.sh
+++ b/libdrm/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libdrm/cloexec.patch
+++ b/libdrm/cloexec.patch
@@ -1,0 +1,15 @@
+Fix compilation on systems that don't provide O_CLOEXEC.
+
+--- include/drm/drm.h.orig     2012-08-11 18:49:45.000000000 +0000
++++ include/drm/drm.h
+@@ -618,7 +618,11 @@ struct drm_get_cap {
+        __u64 value;
+ };
+
++#ifdef O_CLOEXEC
+ #define DRM_CLOEXEC O_CLOEXEC
++#else
++#define DRM_CLOEXEC 0
++#endif
+ struct drm_prime_handle {
+       __u32 handle;

--- a/libdrm/meta.yaml
+++ b/libdrm/meta.yaml
@@ -7,6 +7,9 @@ source:
   url: http://dri.freedesktop.org/libdrm/libdrm-2.4.60.tar.bz2 # [linux]
   md5: 13e35a7a1cf38b4c9c0fa0f8c9be6b93 # [linux]
 
+  patches:
+    - cloexec.patch
+
 about:
     home: http://dri.freedesktop.org/
     license: MIT

--- a/libdrm/meta.yaml
+++ b/libdrm/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: libdrm
+  version: 2.4.60
+
+source:
+  fn: libdrm-2.4.60.tar.bz2 # [linux]
+  url: http://dri.freedesktop.org/libdrm/libdrm-2.4.60.tar.bz2 # [linux]
+  md5: 13e35a7a1cf38b4c9c0fa0f8c9be6b93 # [linux]
+
+about:
+    home: http://dri.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libpciaccess # [linux]
+  run:
+    - libpciaccess # [linux]

--- a/libpciaccess/build.sh
+++ b/libpciaccess/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libpciaccess/meta.yaml
+++ b/libpciaccess/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: libpciaccess
+  version: 0.13.3
+
+source:
+  fn: libpciaccess-0.13.3.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libpciaccess-0.13.3.tar.bz2 # [linux]
+  md5: 1f65be5ffc55641c1846c2f41d180d00 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libx11 # [linux]
+  run:
+    - libx11 # [linux]

--- a/libx11/build.sh
+++ b/libx11/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libx11/meta.yaml
+++ b/libx11/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: libx11
+  version: 1.6.3
+
+source:
+  fn: libX11-1.6.3.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libX11-1.6.3.tar.gz # [linux]
+  md5: 7d16653fe7c36209799175bb3dc1ae46 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - fontconfig # [linux]
+    - libxcb # [linux]
+    - xproto # [linux]
+    - xtrans # [linux]
+  run:
+    - fontconfig # [linux]
+    - libxcb # [linux]
+    - xproto # [linux]
+    - xtrans # [linux]

--- a/libxcb/build.sh
+++ b/libxcb/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxcb/meta.yaml
+++ b/libxcb/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: libxcb
+  version: 1.11
+
+source:
+  fn: libxcb-1.11.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/libxcb-1.11.tar.bz2 # [linux]
+  md5: 5a873ebd383d1a60612dd6ec6b42c781 # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - python # [linux]
+    - pthread-stubs # [linux]
+    - xcb-proto # [linux]
+  run:
+    - pthread-stubs # [linux]
+    - xcb-proto # [linux]

--- a/libxdamage/build.sh
+++ b/libxdamage/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxdamage/meta.yaml
+++ b/libxdamage/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: libxdamage
+  version: 1.1.4
+
+source:
+  fn: libXdamage-1.1.4.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXdamage-1.1.4.tar.bz2 # [linux]
+  md5: 0cf292de2a9fa2e9a939aefde68fd34f # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - damageproto # [linux]
+    - libx11 # [linux]
+    - libxfixes # [linux]
+  run:
+    - damageproto # [linux]
+    - libx11 # [linux]
+    - libxfixes # [linux]

--- a/libxdmcp/build.sh
+++ b/libxdmcp/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxdmcp/meta.yaml
+++ b/libxdmcp/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: libxdmcp
+  version: 1.0.2
+
+source:
+  fn: libXdmcp-1.0.2.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXdmcp-1.0.2.tar.bz2 # [linux]
+  md5: 10facf2bc7cbd5e5c1a698b8a210a582 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/libxext/build.sh
+++ b/libxext/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxext/meta.yaml
+++ b/libxext/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: libxext
+  version: 1.3.3
+
+source:
+  fn: libXext-1.3.3.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXext-1.3.3.tar.bz2 # [linux]
+  md5: 52df7c4c1f0badd9f82ab124fb32eb97 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libx11 # [linux]
+    - xextproto # [linux]
+  run:
+    - libx11 # [linux]
+    - xextproto # [linux]

--- a/libxfixes/build.sh
+++ b/libxfixes/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxfixes/meta.yaml
+++ b/libxfixes/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: libxfixes
+  version: 5.0.1
+
+source:
+  fn: libXfixes-5.0.1.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXfixes-5.0.1.tar.bz2 # [linux]
+  md5: b985b85f8b9386c85ddcfe1073906b4d # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - fixesproto # [linux]
+    - libx11 # [linux]
+  run:
+    - fixesproto # [linux]
+    - libx11 # [linux]

--- a/libxi/build.sh
+++ b/libxi/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxi/meta.yaml
+++ b/libxi/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: libxi
+  version: 1.7.4
+
+source:
+  fn: libXi-1.7.4.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXi-1.7.4.tar.bz2 # [linux]
+  md5: 9c4a69c34b19ec1e4212e849549544cb # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - inputproto # [linux]
+    - libx11 # [linux]
+    - libxext # [linux]
+    - libxfixes # [linux]
+  run:
+    - inputproto # [linux]
+    - libx11 # [linux]
+    - libxext # [linux]
+    - libxfixes # [linux]

--- a/libxmu/build.sh
+++ b/libxmu/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxmu/meta.yaml
+++ b/libxmu/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: libxmu
+  version: 1.1.2
+
+source:
+  fn: libXmu-1.1.2.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libXmu-1.1.2.tar.gz # [linux]
+  md5: d5be323b02e6851607205c8e941b4e61 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libx11 # [linux]
+    - libxext # [linux]
+  run:
+    - libx11 # [linux]
+    - libxext # [linux]

--- a/libxshmfence/build.sh
+++ b/libxshmfence/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/libxshmfence/meta.yaml
+++ b/libxshmfence/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: libxshmfence
+  version: 1.2
+
+source:
+  fn: libxshmfence-1.2.tar.bz2 # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/libxshmfence-1.2.tar.bz2 # [linux]
+  md5: 66662e76899112c0f99e22f2fc775a7e # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/mesa/build.sh
+++ b/mesa/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MAKE_JOBS=$CPU_COUNT
+
+./configure CFLAGS='-O2' CXXFLAGS='-O2'    \
+            --prefix="$PREFIX"             \
+            --enable-texture-float         \
+            --enable-gles1                 \
+            --enable-gles2                 \
+            --enable-osmesa                \
+            --enable-xa                    \
+            --enable-gbm                   \
+            --enable-glx-tls               \
+            --with-egl-platforms="drm,x11" \
+            --with-gallium-drivers="nouveau,r600,svga,swrast"
+make -j $MAKE_JOBS
+make install

--- a/mesa/meta.yaml
+++ b/mesa/meta.yaml
@@ -13,17 +13,25 @@ about:
 
 requirements:
   build:
+    - dri2proto # [linux]
+    - dri3proto # [linux]
     - gcc # [linux]
     - glproto # [linux]
+    - libdrm # [linux]
     - libxi # [linux]
     - libxdamage # [linux]
     - libxmu # [linux]
-    - mako # [linux]
-    - python # [linux]
+    - libxshmfence # [linux]
+    - mako
+    - presentproto # [linux]
+    - python
   run:
+    - dri2proto # [linux]
+    - dri3proto # [linux]
     - glproto # [linux]
+    - libdrm # [linux]
     - libxi # [linux]
     - libxdamage # [linux]
     - libxmu # [linux]
-    - mako # [linux]
-    - python # [linux]
+    - libxshmfence # [linux]
+    - presentproto # [linux]

--- a/mesa/meta.yaml
+++ b/mesa/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: mesa
+  version: 10.5.2
+
+source:
+  fn: mesa-10.5.2.tar.xz # [linux]
+  url: ftp://ftp.freedesktop.org/pub/mesa/10.5.2/mesa-10.5.2.tar.xz # [linux]
+  md5: 528b3b0c0ff330766b9788da04a9fabd # [linux]
+
+about:
+    home: http://www.mesa3d.org/
+    license: MIT
+
+requirements:
+  build:
+    - gcc # [linux]
+    - glproto # [linux]
+    - libxi # [linux]
+    - libxdamage # [linux]
+    - libxmu # [linux]
+    - mako # [linux]
+    - python # [linux]
+  run:
+    - glproto # [linux]
+    - libxi # [linux]
+    - libxdamage # [linux]
+    - libxmu # [linux]
+    - mako # [linux]
+    - python # [linux]

--- a/presentproto/build.sh
+++ b/presentproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/presentproto/meta.yaml
+++ b/presentproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: presentproto
+  version: 1.0
+
+source:
+  fn: presentproto-1.0.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/presentproto-1.0.tar.gz # [linux]
+  md5: 57eaf4bb58e86476ec89cfb42d675961 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/pthread-stubs/build.sh
+++ b/pthread-stubs/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/pthread-stubs/meta.yaml
+++ b/pthread-stubs/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: pthread-stubs
+  version: 0.1
+
+source:
+  fn: libpthread-stubs-0.1.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/libpthread-stubs-0.1.tar.bz2 # [linux]
+  md5: 774eabaf33440d534efe108ef9130a7d # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -49,6 +49,8 @@ chmod +x configure
             -headerdir $PREFIX/include/qt5 \
             -archdatadir $PREFIX/lib/qt5 \
             -datadir $PREFIX/share/qt5 \
+            -L $LIBRARY_PATH \
+            -I $INCLUDE_PATH \
             -release \
             -opensource \
             -confirm-license \
@@ -56,6 +58,7 @@ chmod +x configure
             -nomake examples \
             -nomake tests \
             -fontconfig \
+            -no-libudev \
             -qt-xcb \
             -qt-pcre \
             -qt-xkbcommon \

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -56,8 +56,7 @@ chmod +x configure
             -nomake examples \
             -nomake tests \
             -fontconfig \
-            -qt-libpng \
-            -qt-zlib \
+            -qt-xcb \
             -qt-pcre \
             -qt-xkbcommon \
             -verbose \

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -62,6 +62,7 @@ chmod +x configure
             -qt-xcb \
             -qt-pcre \
             -qt-xkbcommon \
+            -xkb-config-root $LIBRARY_PATH \
             -verbose \
             $CONFIG_OPTS
 

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -42,6 +42,7 @@ chmod +x configure
             -qt-zlib \
             -qt-xcb \
             -qt-pcre \
+            -qt-xkbcommon \
             $CONFIG_OPTS
 
 make -j $MAKE_JOBS

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -40,6 +40,8 @@ chmod +x configure
             -fontconfig \
             -qt-libpng \
             -qt-zlib \
+            -qt-xcb \
+            -qt-pcre \
             $CONFIG_OPTS
 
 make -j $MAKE_JOBS

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -58,9 +58,9 @@ chmod +x configure
             -fontconfig \
             -qt-libpng \
             -qt-zlib \
-            -qt-xcb \
             -qt-pcre \
             -qt-xkbcommon \
+            -verbose \
             $CONFIG_OPTS
 
 make -j $MAKE_JOBS

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 CONFIG_OPTS=" "
-PATH=/usr/bin:/usr/sbin:/bin
 
 if [ `uname` == Linux ]; then
     CONFIG_OPTS+=" -dbus"
@@ -22,6 +21,25 @@ if [ `uname` == Darwin ]; then
     CONFIG_OPTS+=" -no-libudev -no-egl"
 
     MAKE_JOBS=$(sysctl -n hw.ncpu)
+fi
+
+if [ -f /etc/redhat-release ] && grep "CentOS release 5" /etc/redhat-release; then
+
+    # Disable perf events. This file won't compile because of a broken kernel header in CentOS 5.
+    # See http://lists.qt-project.org/pipermail/interest/2015-February/015306.html for error.
+    sed -i "s/#define QTESTLIB_USE_PERF_EVENTS/#undef QTESTLIB_USE_PERF_EVENTS/g" qtbase/src/testlib/qbenchmark_p.h
+
+    # See http://kate-editor.org/2014/12/22/qt-5-4-on-red-hat-enterprise-5/ for explanation
+    # of these options. Basically, these things are left undefined becuase of CentOS 5
+    # problems.
+    CONFIG_OPTS+=" -D _X_INLINE=inline"  # Fix xcb compilation error
+    CONFIG_OPTS+=" -D XK_dead_currency=0xfe6f"
+    CONFIG_OPTS+=" -D XK_ISO_Level5_Lock=0xfe13"
+    CONFIG_OPTS+=" -D FC_WEIGHT_EXTRABLACK=215"
+    CONFIG_OPTS+=" -D FC_WEIGHT_ULTRABLACK=FC_WEIGHT_EXTRABLACK"
+
+    CONFIG_OPTS+=" -D glXGetProcAddress=glXGetProcAddressARB"
+
 fi
 
 chmod +x configure

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -18,30 +18,21 @@ requirements:
     - freetype # [unix]
     - jom # [win]
     - python # [win]
-    - gcc # [linux]
-    - libxcb # [linux]
-    - xcb-util # [linux]
-    - xcb-util-image # [linux]
-    - xcb-util-keysyms # [linux]
-    - xcb-util-wm # [linux]
-    - libx11 # [linux]
     - fontconfig # [linux]
     - gstreamer # [linux]
     - bison # [linux]
     - flex # [linux]
     - sqlite # [linux]
     - icu
+    - zlib # [linux]
+    - xz # [linux]
   run:
     - freetype # [unix]
     - fontconfig # [linux]
-    - libxcb # [linux]
-    - xcb-util # [linux]
-    - xcb-util-keysyms # [linux]
-    - xcb-util-image # [linux]
-    - xcb-util-wm # [linux]
-    - libx11 # [linux]
     - gstreamer # [linux]
     - icu
+    - zlib # [linux]
+    - xz # [linux]
 
 
 about:

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -20,6 +20,11 @@ requirements:
     - python # [win]
     - gcc # [linux]
     - libxcb # [linux]
+    - xcb-util # [linux]
+    - xcb-util-image # [linux]
+    - xcb-util-keysyms # [linux]
+    - xcb-util-wm # [linux]
+    - libx11 # [linux]
     - fontconfig # [linux]
     - gstreamer # [linux]
     - bison # [linux]
@@ -30,6 +35,11 @@ requirements:
     - freetype # [unix]
     - fontconfig # [linux]
     - libxcb # [linux]
+    - xcb-util # [linux]
+    - xcb-util-keysyms # [linux]
+    - xcb-util-image # [linux]
+    - xcb-util-wm # [linux]
+    - libx11 # [linux]
     - gstreamer # [linux]
     - icu
 

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -18,11 +18,18 @@ requirements:
     - freetype # [unix]
     - jom # [win]
     - python # [win]
+    - gcc # [linux]
     - libxcb # [linux]
+    - fontconfig # [linux]
+    - gstreamer # [linux]
+    - bison # [linux]
+    - flex # [linux]
     - icu
   run:
     - freetype # [unix]
+    - fontconfig # [linux]
     - libxcb # [linux]
+    - gstreamer # [linux]
     - icu
 
 

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - gstreamer # [linux]
     - bison # [linux]
     - flex # [linux]
+    - sqlite # [linux]
     - icu
   run:
     - freetype # [unix]

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -18,9 +18,11 @@ requirements:
     - freetype # [unix]
     - jom # [win]
     - python # [win]
+    - libxcb # [linux]
     - icu
   run:
     - freetype # [unix]
+    - libxcb # [linux]
     - icu
 
 

--- a/qt5/meta.yaml
+++ b/qt5/meta.yaml
@@ -18,6 +18,8 @@ requirements:
     - freetype # [unix]
     - jom # [win]
     - python # [win]
+    - libpng # [linux]
+    - jpeg # [linux]
     - fontconfig # [linux]
     - gstreamer # [linux]
     - bison # [linux]
@@ -28,6 +30,8 @@ requirements:
     - xz # [linux]
   run:
     - freetype # [unix]
+    - libpng # [linux]
+    - jpeg # [linux]
     - fontconfig # [linux]
     - gstreamer # [linux]
     - icu

--- a/qt5/notes.md
+++ b/qt5/notes.md
@@ -16,6 +16,14 @@ These may have been optional
 - pcre-devel
 - mesa-libEGL
 
+## Notes concerning CentOS 6
+
+To install all dependencies, simply run:
+- sudo yum install git gcc-g++ *mesa*
+
+All mesa packages are installed, and it turns out the requirements 
+for mesa are the same as the requirements for Qt5 on X11.
+
 ## Notes concerning OS X
 
 - I found it necessary to uninstall the qt4-mac macports package. Qt5 was

--- a/xcb-proto/build.sh
+++ b/xcb-proto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xcb-proto/meta.yaml
+++ b/xcb-proto/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: xcb-proto
+  version: 1.11
+
+source:
+  fn: xcb-proto-1.11.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.bz2 # [linux]
+  md5: 6bf2797445dc6d43e9e4707c082eff9c # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - python # [linux]

--- a/xcb-util-image/build.sh
+++ b/xcb-util-image/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xcb-util-image/meta.yaml
+++ b/xcb-util-image/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: xcb-util-image
+  version: 0.4.0
+
+source:
+  fn: xcb-util-image-0.4.0.tar.gz # [linux]
+  url: http://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.gz # [linux]
+  md5: 32c9c2f72ebd58a2b2e210f27fee86f7 # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libxcb # [linux]
+    - xcb-util # [linux]
+    - xproto # [linux]
+  run:
+    - libxcb # [linux]
+    - xcb-util # [linux]
+    - xproto # [linux]

--- a/xcb-util-keysyms/build.sh
+++ b/xcb-util-keysyms/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xcb-util-keysyms/meta.yaml
+++ b/xcb-util-keysyms/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: xcb-util-keysyms
+  version: 0.4.0
+
+source:
+  fn: xcb-util-keysyms-0.4.0.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.0.tar.bz2 # [linux]
+  md5: 1022293083eec9e62d5659261c29e367 # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libxcb # [linux]
+    - xproto # [linux]
+  run:
+    - libxcb # [linux]
+    - xproto # [linux]

--- a/xcb-util-wm/build.sh
+++ b/xcb-util-wm/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xcb-util-wm/meta.yaml
+++ b/xcb-util-wm/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: xcb-util-wm
+  version: 0.4.1
+
+source:
+  fn: xcb-util-wm-0.4.1.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/xcb-util-wm-0.4.1.tar.bz2 # [linux]
+  md5: 87b19a1cd7bfcb65a24e36c300e03129 # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libxcb # [linux]
+  run:
+    - libxcb # [linux]

--- a/xcb-util/build.sh
+++ b/xcb-util/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xcb-util/meta.yaml
+++ b/xcb-util/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: xcb-util
+  version: 0.4.0
+
+source:
+  fn: xcb-util-0.4.0.tar.bz2 # [linux]
+  url: http://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.bz2 # [linux]
+  md5: 2e97feed81919465a04ccc71e4073313 # [linux]
+
+about:
+    home: http://xcb.freedesktop.org/
+    license: MIT
+
+requirements:
+  build:
+    - libxcb # [linux]
+  run:
+    - libxcb # [linux]

--- a/xextproto/build.sh
+++ b/xextproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xextproto/meta.yaml
+++ b/xextproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: xextproto
+  version: 7.3.0
+
+source:
+  fn: xextproto-7.3.0.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/xextproto-7.3.0.tar.gz # [linux]
+  md5: 37b700baa8c8ea7964702d948dd13821 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/xproto/build.sh
+++ b/xproto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xproto/meta.yaml
+++ b/xproto/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: xproto
+  version: 7.0.27
+
+source:
+  fn: xproto-7.0.27.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/proto/xproto-7.0.27.tar.gz # [linux]
+  md5: f04f535b090f3fd05073370740e99193 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT

--- a/xtrans/build.sh
+++ b/xtrans/build.sh
@@ -3,3 +3,7 @@
 ./configure --prefix="$PREFIX"
 make
 make install
+
+# Move the pkgconfig file to the correct spot
+mkdir -p "$LIBRARY_PATH"/pkgconfig
+mv "$PREFIX"/share/pkgconfig "$LIBRARY_PATH"

--- a/xtrans/build.sh
+++ b/xtrans/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make install

--- a/xtrans/meta.yaml
+++ b/xtrans/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: xtrans
+  version: 1.3.5
+
+source:
+  fn: xtrans-1.3.5.tar.gz # [linux]
+  url: http://xorg.freedesktop.org/releases/individual/lib/xtrans-1.3.5.tar.gz # [linux]
+  md5: 6e4eac1b7c6591da0753052e1eccfb58 # [linux]
+
+about:
+    home: http://xorg.freedesktop.org/
+    license: MIT


### PR DESCRIPTION
As discussed in #261, we want to try and use configure flags like `-qt-pcre` and `-qt-xcb` so we don't have to pull in too many extra dependencies. Note that `-qt-xcb` relies on a lot of `libxcb-*` libraries, so `libxcb` should be a dependency of `qt5`. Also, `libxcb` requires `xcb-proto` and `pthread-stubs`, so I have added those.

The next step, I think, is to add `gstreamer`. 

I tried building on a CentOS 5 vagrant box, but the build fails right after symlinking the `libQtQWidgets.so*` libraries. It could be that more dependencies are missing. I've never used CentOS before, so this could be because I missed a very obvious build package :)