### PR TITLE
Build cairo without X11 support on Mac

### DIFF
--- a/cairo/build.sh
+++ b/cairo/build.sh
@@ -2,6 +2,14 @@
 
 export CFLAGS="-I$PREFIX/include -L$PREFIX/lib"
 
+# As of Mac OS 10.8, X11 is no longer included by default ( https://support.apple.com/en-us/HT201341 ).
+# Due to this change, we disable building X11 support for cairo on Mac by default.
+export XWIN_ARGS=""
+if [ `uname` == Darwin ]; then
+   export XWIN_ARGS="--disable-gtk-doc --disable-xlib -disable-xcb --disable-glitz"
+fi
+
+
 ./configure                 \
     --prefix=$PREFIX        \
     --disable-static        \
@@ -11,7 +19,8 @@ export CFLAGS="-I$PREFIX/include -L$PREFIX/lib"
     --enable-ps             \
     --enable-pdf            \
     --enable-svg            \
-    --disable-gtk-doc
+    --disable-gtk-doc       \
+    $XWIN_ARGS
 make
 make install
 

--- a/cairo/meta.yaml
+++ b/cairo/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 8e4ff32b82c3b39387eb6f5c59ef848e
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
As one may want cairo, but may not have or want to build X11 to use it.