### PR TITLE
Add pixman (required by cairo)

### DIFF
--- a/pixman/build.sh
+++ b/pixman/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+./configure --prefix=$PREFIX
+make -j
+make install

--- a/pixman/meta.yaml
+++ b/pixman/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: pixman
+  version: "0.32.6"
+
+source:
+  fn: pixman-0.32.6.tar.gz
+  url: http://cairographics.org/releases/pixman-0.32.6.tar.gz
+
+build:
+  number: 0
+
+about:
+  home: http://cairographics.org
+  license: GNU Lesser General Public License (LGPL) version 2.1 or the Mozilla Public License (MPL) version 1.1 at your option.


### PR DESCRIPTION
Appear to be a dependency of cairo ( https://github.com/conda/conda-recipes/blob/master/cairo/meta.yaml#L18 ) ( https://github.com/conda/conda-recipes/blob/master/cairo/meta.yaml#L24 ), but is not currently included. This remedies that.