### PR TITLE
[WIP] Split GDAL package into libgdal and gdal

### DIFF
--- a/gdal/bld.bat
+++ b/gdal/bld.bat
@@ -7,13 +7,9 @@ if errorlevel 1 exit 1
 %PYTHON% setup.py build_scripts
 if errorlevel 1 exit 1
 
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --root=C:\
 if errorlevel 1 exit 1
 
 REM copy gdal111.dll to python directory
-copy %LIBRARY_BIN%\gdal111.dll %SP_DIR%\osgeo\
+copy %LIBRARY_BIN%\gdal111.dll %SP_DIR%\osgeo
 if errorlevel 1 exit 1
-
-if %PY3K%==1 (
-    del %PREFIX%\Lib\lib2to3\*.pickle
-)

--- a/gdal/bld.bat
+++ b/gdal/bld.bat
@@ -1,7 +1,19 @@
-for %%x in (gdal.py gdalconst.py gdalnumeric.py ogr.py osr.py osgeo) do (
-    move %SRC_DIR%\%%x %SP_DIR%
-    if errorlevel 1 exit 1
-)
-
-move %SRC_DIR%\GDAL-%PKG_VERSION%.dist-info %SP_DIR%
+%PYTHON% setup.py build_ext --include-dirs %LIBRARY_INC% --library-dirs %LIBRARY_LIB% --gdal-config %LIBRARY_BIN%\gdal-config
 if errorlevel 1 exit 1
+
+%PYTHON% setup.py build_py
+if errorlevel 1 exit 1
+
+%PYTHON% setup.py build_scripts
+if errorlevel 1 exit 1
+
+%PYTHON% setup.py install
+if errorlevel 1 exit 1
+
+REM copy gdal111.dll to python directory
+copy %LIBRARY_BIN%\gdal111.dll %SP_DIR%\osgeo\
+if errorlevel 1 exit 1
+
+if %PY3K%==1 (
+    del %PREFIX%\Lib\lib2to3\*.pickle
+)

--- a/gdal/build.sh
+++ b/gdal/build.sh
@@ -2,19 +2,25 @@
 
 # http://www.michael-joost.de/gdal_install.html
 unset CC CPP CXX
+export MAKEFLAGS=' -j8'
 
+if [ `uname` == Darwin ]; then
+    export LDFLAGS="$LDFLAGS -headerpad_max_install_names -liconv"
+fi
+
+export PYTHON=
 bash configure \
-    --with-python=$PREFIX/bin/python \
+    --without-python \
     --with-hdf5=$PREFIX \
     --with-netcdf=$PREFIX \
     --prefix=$PREFIX
 make
 make install
 
-ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
-DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
-mkdir -p $ACTIVATE_DIR
-mkdir -p $DEACTIVATE_DIR
+#ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+#DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+#mkdir -p $ACTIVATE_DIR
+#mkdir -p $DEACTIVATE_DIR
 
-cp $RECIPE_DIR/posix/activate.sh $ACTIVATE_DIR/gdal-activate.sh
-cp $RECIPE_DIR/posix/deactivate.sh $DEACTIVATE_DIR/gdal-deactivate.sh
+#cp $RECIPE_DIR/posix/activate.sh $ACTIVATE_DIR/gdal-activate.sh
+#cp $RECIPE_DIR/posix/deactivate.sh $DEACTIVATE_DIR/gdal-deactivate.sh

--- a/gdal/build.sh
+++ b/gdal/build.sh
@@ -1,26 +1,4 @@
-#!/bin/bash
-
-# http://www.michael-joost.de/gdal_install.html
-unset CC CPP CXX
-export MAKEFLAGS=' -j8'
-
-if [ `uname` == Darwin ]; then
-    export LDFLAGS="$LDFLAGS -headerpad_max_install_names -liconv"
-fi
-
-export PYTHON=
-bash configure \
-    --without-python \
-    --with-hdf5=$PREFIX \
-    --with-netcdf=$PREFIX \
-    --prefix=$PREFIX
-make
-make install
-
-#ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
-#DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
-#mkdir -p $ACTIVATE_DIR
-#mkdir -p $DEACTIVATE_DIR
-
-#cp $RECIPE_DIR/posix/activate.sh $ACTIVATE_DIR/gdal-activate.sh
-#cp $RECIPE_DIR/posix/deactivate.sh $DEACTIVATE_DIR/gdal-deactivate.sh
+$PYTHON setup.py build_ext --include-dirs $INCLUDE_PATH --library-dirs $LIBRARY_PATH --gdal-config gdal-config
+$PYTHON setup.py build_py
+$PYTHON setup.py build_scripts
+$PYTHON setup.py install

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -12,18 +12,6 @@ requirements:
     - hdf5           [unix]
     - libnetcdf      [unix]
 
-test:
-  files:
-    - os1_hw.py
-    - sites.dbf
-    - sites.sbn
-    - sites.sbx
-    - sites.shp
-    - sites.shx
-  imports:
-    - osgeo.gdal
-    - osgeo.ogr
-
 about:
   home: http://www.gdal.org/
   license: MIT

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -12,14 +12,10 @@ requirements:
     - python
     - libgdal
     - numpy          [unix]
-    - hdf5           [unix]
-    - libnetcdf      [unix]
   run:
     - python
     - libgdal
     - numpy
-    - hdf5           [unix]
-    - libnetcdf      [unix]
 
 test:
   files:

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -1,18 +1,39 @@
 package:
-  name: libgdal
+  name: gdal
   version: 1.11.2
 
 source:
-  fn: gdal-1.11.2.tar.gz
-  url:  http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
-  md5: 866a46f72b1feadd60310206439c1a76
+  fn: GDAL-1.11.2.tar.gz
+  md5: 4351163daa608ef4aca7e9fc6ebb868a
+  url: https://pypi.python.org/packages/source/G/GDAL/GDAL-1.11.2.tar.gz
 
 requirements:
   build:
+    - python
+    - libgdal
+    - numpy          [unix]
+    - hdf5           [unix]
+    - libnetcdf      [unix]
+  run:
+    - python
+    - libgdal
+    - numpy
     - hdf5           [unix]
     - libnetcdf      [unix]
 
+test:
+  files:
+    - os1_hw.py
+    - sites.dbf
+    - sites.sbn
+    - sites.sbx
+    - sites.shp
+    - sites.shx
+  imports:
+    - osgeo.ogr
+    - osgeo.gdal
+
 about:
-  home: http://www.gdal.org/
+  home: https://pypi.python.org/pypi/GDAL/
   license: MIT
   summary: Geospatial Data Abstraction Library

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -28,6 +28,9 @@ test:
   imports:
     - osgeo.ogr
     - osgeo.gdal
+    - osgeo.osr
+    - osgeo.gdal_array
+    - osgeo.gdalconst
 
 about:
   home: https://pypi.python.org/pypi/GDAL/

--- a/gdal/meta.yaml
+++ b/gdal/meta.yaml
@@ -1,21 +1,14 @@
 package:
-  name: gdal
+  name: libgdal
   version: 1.11.2
 
 source:
-  fn: gdal-1.11.2.tar.gz                                         [unix]
-  url:  http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz [unix]
-  md5: 866a46f72b1feadd60310206439c1a76                          [unix]
+  fn: gdal-1.11.2.tar.gz
+  url:  http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
+  md5: 866a46f72b1feadd60310206439c1a76
 
 requirements:
   build:
-    - python
-    - numpy          [unix]
-    - hdf5           [unix]
-    - libnetcdf      [unix]
-  run:
-    - python
-    - numpy
     - hdf5           [unix]
     - libnetcdf      [unix]
 
@@ -28,10 +21,10 @@ test:
     - sites.shp
     - sites.shx
   imports:
-    - osgeo                [not win]
-    - osgeo._gdal_array    [not win]
+    - osgeo.gdal
+    - osgeo.ogr
 
 about:
   home: http://www.gdal.org/
   license: MIT
-  summary: 'GDAL: Geospatial Data Abstraction Library'
+  summary: Geospatial Data Abstraction Library

--- a/libgdal/bld.bat
+++ b/libgdal/bld.bat
@@ -1,0 +1,25 @@
+REM build
+
+if "%ARCH%"=="64" (
+    set WIN64="WIN64=YES"
+) else (
+    set WIN64=
+)
+
+nmake /f makefile.vc ^
+    %WIN64% ^
+    GDAL_HOME=%LIBRARY_PREFIX% ^
+    BINDIR=%LIBRARY_BIN% ^
+    LIBDIR=%LIBRARY_LIB% ^
+    INCDIR=%LIBRARY_INC% ^
+    DATADIR=%LIBRARY_PREFIX%\data
+if errorlevel 1 exit 1
+
+nmake /f makefile.vc devinstall ^
+    %WIN64% ^
+    GDAL_HOME=%LIBRARY_PREFIX% ^
+    BINDIR=%LIBRARY_BIN% ^
+    LIBDIR=%LIBRARY_LIB% ^
+    INCDIR=%LIBRARY_INC% ^
+    DATADIR=%LIBRARY_PREFIX%\data
+if errorlevel 1 exit 1

--- a/libgdal/build.sh
+++ b/libgdal/build.sh
@@ -18,9 +18,9 @@ make
 make install
 
 # strip symbols from library
-strip --strip-unneeded $LIBRARY_LIB/libgdal.so.1.18.2
+strip --strip-unneeded $PREFIX/lib/libgdal.so.1.18.2
 
-rm $LIBRARY_LIB/libgdal.a
+rm $PREFIX/lib/libgdal.a
 
 #ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 #DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d

--- a/libgdal/build.sh
+++ b/libgdal/build.sh
@@ -17,6 +17,11 @@ bash configure \
 make
 make install
 
+# strip symbols from library
+strip --strip-unneeded $LIBRARY_LIB/libgdal.so.1.18.2
+
+rm $LIBRARY_LIB/libgdal.a
+
 #ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 #DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
 #mkdir -p $ACTIVATE_DIR

--- a/libgdal/build.sh
+++ b/libgdal/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# http://www.michael-joost.de/gdal_install.html
+unset CC CPP CXX
+export MAKEFLAGS=' -j8'
+
+if [ `uname` == Darwin ]; then
+    export LDFLAGS="$LDFLAGS -headerpad_max_install_names -liconv"
+fi
+
+export PYTHON=
+bash configure \
+    --without-python \
+    --with-hdf5=$PREFIX \
+    --with-netcdf=$PREFIX \
+    --prefix=$PREFIX
+make
+make install
+
+#ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+#DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+#mkdir -p $ACTIVATE_DIR
+#mkdir -p $DEACTIVATE_DIR
+
+#cp $RECIPE_DIR/posix/activate.sh $ACTIVATE_DIR/gdal-activate.sh
+#cp $RECIPE_DIR/posix/deactivate.sh $DEACTIVATE_DIR/gdal-deactivate.sh

--- a/libgdal/build.sh
+++ b/libgdal/build.sh
@@ -14,13 +14,12 @@ bash configure \
     --with-hdf5=$PREFIX \
     --with-netcdf=$PREFIX \
     --prefix=$PREFIX
+    --disable-static
 make
 make install
 
 # strip symbols from library
 strip --strip-unneeded $PREFIX/lib/libgdal.so.1.18.2
-
-rm $PREFIX/lib/libgdal.a
 
 #ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
 #DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d

--- a/libgdal/build.sh
+++ b/libgdal/build.sh
@@ -13,7 +13,7 @@ bash configure \
     --without-python \
     --with-hdf5=$PREFIX \
     --with-netcdf=$PREFIX \
-    --prefix=$PREFIX
+    --prefix=$PREFIX \
     --disable-static
 make
 make install

--- a/libgdal/meta.yaml
+++ b/libgdal/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 1.11.2
 
 source:
-  fn: gdal-1.11.2.tar.gz
-  url:  http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
+  fn: libgdal-1.11.2.tar.gz
+  url: http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
   md5: 866a46f72b1feadd60310206439c1a76
 
 requirements:
@@ -17,7 +17,7 @@ requirements:
     - libnetcdf      [unix]
 
 build:
-  detect_binary_files_with_prefix: true
+  detect_binary_files_with_prefix: false
 
 about:
   home: http://www.gdal.org/

--- a/libgdal/meta.yaml
+++ b/libgdal/meta.yaml
@@ -12,6 +12,10 @@ requirements:
     - hdf5           [unix]
     - libnetcdf      [unix]
 
+  run:
+    - hdf5           [unix]
+    - libnetcdf      [unix]
+
 build:
   detect_binary_files_with_prefix: true
 

--- a/libgdal/meta.yaml
+++ b/libgdal/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: libgdal
+  version: 1.11.2
+
+source:
+  fn: gdal-1.11.2.tar.gz
+  url:  http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
+  md5: 866a46f72b1feadd60310206439c1a76
+
+requirements:
+  build:
+    - hdf5           [unix]
+    - libnetcdf      [unix]
+
+build:
+  detect_binary_files_with_prefix: true
+
+about:
+  home: http://www.gdal.org/
+  license: MIT
+  summary: Geospatial Data Abstraction Library


### PR DESCRIPTION
This will split gdal into libgdal (python independent) and gdal (python bindings).  All packages are built from source on each of the platforms.

TODO:
- [ ] Fix build errors on OS X (failing on my system with an error about libiconv)
- [x] Strip binaries on linux (they are huge, stripping them reduces their size ~75%)

Feedback/testing welcome.
