### PR TITLE
PyDAS (Differential-Algebraic Solver)

### DIFF
--- a/pydas/bld.bat
+++ b/pydas/bld.bat
@@ -1,2 +1,0 @@
-%PYTHON% setup.py install
-if errorlevel 1 exit 1

--- a/pydas/bld.bat
+++ b/pydas/bld.bat
@@ -1,0 +1,2 @@
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/pydas/build.sh
+++ b/pydas/build.sh
@@ -1,6 +1,6 @@
-CC=${PREFIX}/bin/gcc
-CXX=${PREFIX}/bin/g++
-F77=${PREFIX}/bin/gfortran
+export CC=${PREFIX}/bin/gcc
+export CXX=${PREFIX}/bin/g++
+export F77=${PREFIX}/bin/gfortran
 wget -P daspk31 http://www.cs.ucsb.edu/~cse/Software/daspk31.tgz
 make
 $PYTHON setup.py daspk install

--- a/pydas/build.sh
+++ b/pydas/build.sh
@@ -1,3 +1,6 @@
+CC=${PREFIX}/bin/gcc
+CXX=${PREFIX}/bin/g++
+F77=${PREFIX}/bin/gfortran
 wget -P daspk31 http://www.cs.ucsb.edu/~cse/Software/daspk31.tgz
 make
 $PYTHON setup.py daspk install

--- a/pydas/build.sh
+++ b/pydas/build.sh
@@ -1,0 +1,3 @@
+wget -P daspk31 http://www.cs.ucsb.edu/~cse/Software/daspk31.tgz
+make
+$PYTHON setup.py daspk install

--- a/pydas/meta.yaml
+++ b/pydas/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: pydas
+  version: "0.1.0"
+
+source:
+  #git_tag: 0.1.0
+  git_url: https://github.com/GreenGroup/PyDAS.git
+
+requirements:
+  build:
+    - gcc
+    - python
+    - setuptools
+    - cython
+    - numpy
+    - wget
+  run:
+    - libgcc
+    - python
+    - numpy
+
+test:
+  requires:
+    - nose
+  imports:
+    - pydas
+    - pydas.dassl
+    - pydas.daspk
+  commands:
+    - nosetests $SRC_DIR/tests/*.py
+
+about:
+  home: http://github.com/GreenGroup/PyDAS
+  license: MIT
+  summary: "A Python wrapper to several differential algebraic system solvers, namely DASSL and DASPK."

--- a/pydas/meta.yaml
+++ b/pydas/meta.yaml
@@ -27,7 +27,7 @@ test:
     - pydas.dassl
     - pydas.daspk
   commands:
-    - nosetests $SRC_DIR/tests/*.py
+    - cd $SRC_DIR/tests && nosetests *.py
 
 about:
   home: http://github.com/GreenGroup/PyDAS

--- a/pydas/meta.yaml
+++ b/pydas/meta.yaml
@@ -10,7 +10,7 @@ requirements:
     - gcc # [unix]
     - python
     - setuptools
-    - cython
+    - cython ==0.21
     - numpy
     - wget
   run:

--- a/pydas/meta.yaml
+++ b/pydas/meta.yaml
@@ -3,19 +3,18 @@ package:
   version: "0.1.0"
 
 source:
-  #git_tag: 0.1.0
   git_url: https://github.com/GreenGroup/PyDAS.git
 
 requirements:
   build:
-    - gcc
+    - gcc # [unix]
     - python
     - setuptools
     - cython
     - numpy
     - wget
   run:
-    - libgcc
+    - libgcc # [unix]
     - python
     - numpy
 

--- a/pydas/meta.yaml
+++ b/pydas/meta.yaml
@@ -22,12 +22,13 @@ requirements:
 test:
   requires:
     - nose
+    - matplotlib
   imports:
     - pydas
     - pydas.dassl
     - pydas.daspk
   commands:
-    - cd $SRC_DIR/tests && nosetests *.py
+    - nosetests -P --all-modules -v -w $SRC_DIR/tests
 
 about:
   home: http://github.com/GreenGroup/PyDAS


### PR DESCRIPTION
**Update:**
This recipe now works (tested on MacOS X) and could be pulled.

---
*Summary of debugging*
Problems with `Library not loaded: @rpath/./libgfortran.3.dylib` during testing were because it was using the compiled libraries from the `conda-bld` folders, not those installed into the `_test` environment. This was because `nosetests`, upon discovering tests as part of a package, manipulates the python path to add that package. The solution was to add the `-P` flag to `nosetests` in testing, so that it leaves the python path alone.

*original discussion, in case it helps other people:*
The trouble I have, on Mac OS X, stem from linking to libgcc.

Toward the end of the build process I see this:
```
Finished processing dependencies for PyDAS==0.1.0
found egg dir: /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/PyDAS-0.1.0-py2.7-macosx-10.5-x86_64.egg
number of files: 7
Fixing permissions
install_name_tool -change /Users/rwest/anaconda/envs/_build/lib/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/daspk.so

install_name_tool -id @rpath/python2.7/site-packages/pydas/libgfortran.3.dylib /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/daspk.so

install_name_tool -add_rpath @loader_path/../../../ /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/daspk.so

install_name_tool -change /Users/rwest/anaconda/envs/_build/lib/libgcc_s.1.dylib @rpath/libgcc_s.1.dylib /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/dassl.so

install_name_tool -id @rpath/python2.7/site-packages/pydas/libgfortran.3.dylib /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/dassl.so

install_name_tool -add_rpath @loader_path/../../../ /Users/rwest/anaconda/envs/_build/lib/python2.7/site-packages/pydas/dassl.so

Fixing permissions
BUILD END: pydas-0.1.0-np19py27_0
```
It looks OK, but it then goes on to run the tests, which fail because they cannot load the library `@rpath/./libgfortran.3.dylib` because of `image not found`:

```
+ nosetests /Users/rwest/anaconda/conda-bld/work/tests/__init__.py /Users/rwest/anaconda/conda-bld/work/tests/daspkTest.py /Users/rwest/anaconda/conda-bld/work/tests/dasslTest.py
EE
======================================================================
ERROR: Failure: ImportError (dlopen(/Users/rwest/anaconda/conda-bld/work/pydas/daspk.so, 2): Library not loaded: @rpath/./libgfortran.3.dylib
  Referenced from: /Users/rwest/anaconda/conda-bld/work/pydas/daspk.so
  Reason: image not found)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/loader.py", line 420, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/rwest/anaconda/conda-bld/work/tests/daspkTest.py", line 10, in <module>
    from pydas.daspk import DASPK
ImportError: dlopen(/Users/rwest/anaconda/conda-bld/work/pydas/daspk.so, 2): Library not loaded: @rpath/./libgfortran.3.dylib
  Referenced from: /Users/rwest/anaconda/conda-bld/work/pydas/daspk.so
  Reason: image not found

======================================================================
ERROR: Failure: ImportError (dlopen(/Users/rwest/anaconda/conda-bld/work/pydas/dassl.so, 2): Library not loaded: @rpath/./libgfortran.3.dylib
  Referenced from: /Users/rwest/anaconda/conda-bld/work/pydas/dassl.so
  Reason: image not found)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/loader.py", line 420, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/rwest/anaconda/envs/_test/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/rwest/anaconda/conda-bld/work/tests/dasslTest.py", line 10, in <module>
    from pydas.dassl import DASSL
ImportError: dlopen(/Users/rwest/anaconda/conda-bld/work/pydas/dassl.so, 2): Library not loaded: @rpath/./libgfortran.3.dylib
  Referenced from: /Users/rwest/anaconda/conda-bld/work/pydas/dassl.so
  Reason: image not found
``` 

Advice would be greatly appreciated! Thanks