### PR TITLE
Cairocffi - tested on Mac

### DIFF
--- a/cairocffi/bld.bat
+++ b/cairocffi/bld.bat
@@ -1,8 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/cairocffi/bld.bat
+++ b/cairocffi/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/cairocffi/build.sh
+++ b/cairocffi/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/cairocffi/build.sh
+++ b/cairocffi/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-$PYTHON setup.py install
-
+$PYTHON setup.py install --single-version-externally-managed --root /
 # Add more build steps here, if they are necessary.
 
 # See

--- a/cairocffi/meta.yaml
+++ b/cairocffi/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: cairocffi
+  version: "0.6"
+
+source:
+  fn: cairocffi-0.6.tar.gz
+  url: https://pypi.python.org/packages/source/c/cairocffi/cairocffi-0.6.tar.gz
+  md5: af0e93b31be42a8f2be23b1234336496
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - cairocffi = cairocffi:main
+    #
+    # Would create an entry point called cairocffi that calls cairocffi.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cffi >=0.6
+
+  run:
+    - python
+    - cffi >=0.6
+
+test:
+  # Python imports
+  imports:
+    - cairocffi
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/SimonSapin/cairocffi
+  license: BSD License
+  summary: 'cffi-based cairo bindings for Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/cairocffi/meta.yaml
+++ b/cairocffi/meta.yaml
@@ -29,18 +29,10 @@ test:
   # Python imports
   imports:
     - cairocffi
-
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
+    
+  requires:
+    - pytest
+    - nose
 
 about:
   home: https://github.com/SimonSapin/cairocffi

--- a/cairocffi/meta.yaml
+++ b/cairocffi/meta.yaml
@@ -6,24 +6,13 @@ source:
   fn: cairocffi-0.6.tar.gz
   url: https://pypi.python.org/packages/source/c/cairocffi/cairocffi-0.6.tar.gz
   md5: af0e93b31be42a8f2be23b1234336496
-#  patches:
-   # List any patch files here
-   # - fix.patch
+  patches:
+   - search-conda-libs.diff
 
-# build:
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - cairocffi = cairocffi:main
-    #
-    # Would create an entry point called cairocffi that calls cairocffi.main()
-
-
+build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
 
 requirements:
   build:
@@ -34,6 +23,7 @@ requirements:
   run:
     - python
     - cffi >=0.6
+    - cairo
 
 test:
   # Python imports

--- a/cairocffi/run_test.sh
+++ b/cairocffi/run_test.sh
@@ -1,0 +1,4 @@
+
+#cp $SRC_DIR/cairocffi/test_cairo.py ./
+sed -e "s/^from . import/from cairocffi import/g" -e "s/^from \./from cairocffi./g" $SRC_DIR/cairocffi/test_cairo.py > test_cairo.py
+nosetests -P test_cairo.py

--- a/cairocffi/search-conda-libs.diff
+++ b/cairocffi/search-conda-libs.diff
@@ -1,0 +1,17 @@
+To avoid the need to set LD_LIBRARY_PATH or whatever, we make the script
+also search the anaconda environments /lib folder.
+
+diff --git a/cairocffi/__init__.py b/cairocffi/__init__.py
+index 2b8f82b..6b67d8b 100644
+--- cairocffi/__init__.py
++++ cairocffi/__init__.py
+@@ -38,6 +38,11 @@ ffi = FFI()
+ ffi.cdef(constants._CAIRO_HEADERS)
+ CAIRO_NAMES = ['libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll',
+                'cairo', 'libcairo-2']
++# Also search in anaconda folder, for the purposes of conda environments only
++import os
++CAIRO_NAMES.extend(
++    [os.path.join('/opt/anaconda1anaconda2anaconda3','lib',name)
++     for name in CAIRO_NAMES])
+ cairo = dlopen(ffi, *CAIRO_NAMES)


### PR DESCRIPTION
I expect @SimonSapin could do a better job, but here's a recipe for cairocffi that seems to be working for me (on Mac OS).

I wrote a small patch so that it would look in your conda environment for the cairo libraries, rather than just the OS's default places.

(I'm trying cairocffi because I can't get my py2cairo recipe to work)