### PR TITLE
qt: Require explicit libpng dependency

### DIFF
--- a/qt/meta.yaml
+++ b/qt/meta.yaml
@@ -19,11 +19,13 @@ requirements:
     - freetype    >=2.5.2    [unix]
     - fontconfig  >=2.11.1   [linux]
     - openssl
+    - libpng      1.6*
 
   run:
     - freetype    >=2.5.2    [unix]
     - fontconfig  >=2.11.1   [linux]
     - openssl
+    - libpng      1.6*
 
 about:
     home: http://qt-project.org


### PR DESCRIPTION
This PR adds `libpng` as an explicit dependency of Qt, and requires a specific version.

As of 3f76b2f6c9d5fa516f47370f765d3d0534c7d74b there is an explicit dependency on the `libpng` package.  (Technically, the dependency is already included indirectly via `freetype`, but that's not really enough in this case.)

Since `libQtGui.so` links directly against `libpng.so`, if you build Qt against libpng 1.5, you can't use libpng 1.6 at runtime.

This can be demonstrated by attempting to install qt 4.8.6-3 (which was apparently built against libpng=1.6) and libpng 1.5 on a system that does not already have libpng 1.6 installed in the system somewhere.

```
$ conda create -y -n test-qt python=2.7.9 pyqt qt=4.8.6=3 libpng=1.5
$ source activate test-qt
$ python -c "from PyQt4 import QtGui"
....
ImportError: libpng16.so.16: cannot open shared object file: No such file or directory

```