### PR TITLE
fix test-noarch

### DIFF
--- a/test-noarch/build.sh
+++ b/test-noarch/build.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-echo "Hello, I'm a noarch package" > $PREFIX/hello.txt
+$PYTHON setup.py install
+
+EXAMPLES=$PREFIX/Examples
+mkdir $EXAMPLES
+mv examples $EXAMPLES/bokeh

--- a/test-noarch/meta.yaml
+++ b/test-noarch/meta.yaml
@@ -1,9 +1,46 @@
-# This is a sample conda recipe, which is used for testing features
-# in the conda build command.
-
 package:
-  name: test-noarch
-  version: 1.0
+  name: bokeh
+  version: 0.7.1
+
+source:
+  fn: bokeh-0.7.1.tar.gz
+  url: https://pypi.python.org/packages/source/b/bokeh/bokeh-0.7.1.tar.gz
+  md5: 426f2b0850018fab1407f2e7ed129544
 
 build:
-  noarch: True
+  noarch_python: True
+  number: 1
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - numpy
+    - pandas
+    - flask
+    - jinja2
+    - markupsafe
+    - werkzeug
+    - greenlet
+    - dateutil
+    - pytz
+    - requests
+    - six
+    - pygments
+    - pyyaml
+    - pyzmq
+    - tornado
+
+test:
+  requires:
+    - nose
+    - mock
+  commands:
+    - bokeh-server -h
+  imports:
+    - bokeh
+
+about:
+  home: https://github.com/ContinuumIO/Bokeh
+  license: New BSD

--- a/test-noarch/run_test.py
+++ b/test-noarch/run_test.py
@@ -1,0 +1,8 @@
+import sys
+import bokeh
+
+if sys.platform != 'win32':
+    bokeh.test(verbosity=2, exit=False)
+
+print('bokeh.__version__: %s' % bokeh.__version__)
+#assert bokeh.__version__ == '0.7.1'


### PR DESCRIPTION
PR conda/conda-build#317 introduced major changes in the noarch option which made earlier test example obsolete. This test package is taken from conda-build/example_packages/noarch_python
