### PR TITLE
python-levenshtein: Add an import test.

### DIFF
--- a/python-levenshtein/meta.yaml
+++ b/python-levenshtein/meta.yaml
@@ -36,7 +36,8 @@ requirements:
 
 test:
   # Python imports
-  # imports:
+  imports:
+    - Levenshtein
 
   #commands:
     # You can put test commands to be run here.  Use this to test that the


### PR DESCRIPTION
Old `meta.yml` was invalid (so was unable to build) as it had nothing in `test`, but kept the key. Instead of dropping the tests, import the module instead. Tested on Mac OS 10.9 and CentOS 6.3.