### PR TITLE
nbdiff: Depends on `jsonschema` so require it.

### DIFF
--- a/nbdiff/meta.yaml
+++ b/nbdiff/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - jinja2
     - ipython
     - python-levenshtein
+    - jsonschema
 
   run:
     - python
@@ -44,6 +45,7 @@ requirements:
     - python-levenshtein
     - sqlalchemy
     - argparse # [py26]
+    - jsonschema
 
 test:
   # Python imports


### PR DESCRIPTION
Was unable to build successfully without `jsonschema` so it was added as a requirement.