### PR TITLE
Add jq, a sed-like command line tool for JSON

### DIFF
--- a/jq/build.sh
+++ b/jq/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+chmod +x configure
+
+./configure --prefix=$PREFIX 
+
+make -j
+make install

--- a/jq/meta.yaml
+++ b/jq/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: jq
+  version: 1.3
+
+source:
+  fn: jq-1.3.tar.gz
+  url: http://stedolan.github.io/jq/download/source/jq-1.3.tar.gz
+  md5: 26081b05d22525eca5cbdd8f9f4db17d
+
+build:
+  number: 1
+
+about:
+    home: http://stedolan.github.io/jq/
+    license:  MIT


### PR DESCRIPTION
Tested on Mac OS 10.9 and CentOS 6.3.