### PR TITLE
Update jq to 1.4

### DIFF
--- a/jq/configure.patch
+++ b/jq/configure.patch
@@ -1,0 +1,18 @@
+diff --git configure configure
+index 44eee99..a5a18d3 100755
+--- configure
++++ configure
+@@ -12958,9 +12958,10 @@ elif $YACC --help | grep -- --warnings >/dev/null; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+ $as_echo "ok" >&6; }
+ else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-  as_fn_error $? "You need bison version 2.5 or more recent." "$LINENO" 5
++  :
++#  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++#$as_echo "no" >&6; }
++#  as_fn_error $? "You need bison version 2.5 or more recent." "$LINENO" 5
+ fi
+ 
+ 

--- a/jq/meta.yaml
+++ b/jq/meta.yaml
@@ -1,11 +1,14 @@
 package:
   name: jq
-  version: 1.3
+  version: 1.4
 
 source:
-  fn: jq-1.3.tar.gz
-  url: http://stedolan.github.io/jq/download/source/jq-1.3.tar.gz
-  md5: 26081b05d22525eca5cbdd8f9f4db17d
+  fn: jq-1.4.tar.gz
+  url: http://stedolan.github.io/jq/download/source/jq-1.4.tar.gz
+  md5: e3c75a4f805bb5342c9f4b3603fb248f
+
+  patches:
+    - configure.patch
 
 build:
   number: 1


### PR DESCRIPTION
Updated the version of `jq`. Originally, this included `bison`. This has been dropped as patching `configure` allowed this error to be bypassed. As it was determined that `bison` was not being used, excluding this dependencies did not cause a problem.