### PR TITLE
WIP: JDK build fixes

### DIFF
--- a/jdk/build.sh
+++ b/jdk/build.sh
@@ -3,7 +3,7 @@
 #### Download in build because we have to set cookies ####
 # Check if we're on OS X
 if [ $(uname) = "Darwin" ]; then
-	curl -b gpw_e24=http%3A%2F%2Fwww.oracle.com -o jdk.dmg -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-macosx-x64.dmg'
+	curl -v -j -k -L -H "Cookie: oraclelicense=accept-securebackup-cookie" -o jdk.dmg -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-macosx-x64.dmg'
 
 	# Extract files like in
 	# http://stackoverflow.com/questions/15217200/how-to-install-java-7-on-mac-in-custom-location

--- a/jdk/build.sh
+++ b/jdk/build.sh
@@ -14,9 +14,9 @@ if [ $(uname) = "Darwin" ]; then
 	mv Contents/Home "$PREFIX/jdk"
 else
 	if [ "$ARCH" = "32" ]; then
-		curl -b gpw_e24=http%3A%2F%2Fwww.oracle.com -o jdk.tar.gz -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-i586.tar.gz'
+		curl -v -j -k -L -H "Cookie: oraclelicense=accept-securebackup-cookie" -b gpw_e24=http%3A%2F%2Fwww.oracle.com -o jdk.tar.gz -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-i586.tar.gz'
 	else
-		curl -b gpw_e24=http%3A%2F%2Fwww.oracle.com -o jdk.tar.gz -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-x64.tar.gz'
+		curl -v -j -k -L -H "Cookie: oraclelicense=accept-securebackup-cookie" -b gpw_e24=http%3A%2F%2Fwww.oracle.com -o jdk.tar.gz -L 'http://download.oracle.com/otn-pub/java/jdk/7u51-b13/jdk-7u51-linux-x64.tar.gz'
 	fi
 
 	# Extract files


### PR DESCRIPTION
It appears that there are some issues with the JDK recipe now. In particular, the download strategy doesn't work due to cookies and redirects. I have fixed this problem.

However, it seems there are other issues. For instance, at least one of the libraries on Mac fails to be amended by `install_name_tool`. On Linux, there are libraries that appear to missing.

As a consequence, it may be necessary to switch to building OpenJDK from source or something similar.