### PR TITLE
WIP: Add awscli (and required dependencies)

### DIFF
--- a/awscli/bld.bat
+++ b/awscli/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/awscli/build.sh
+++ b/awscli/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/awscli/meta.yaml
+++ b/awscli/meta.yaml
@@ -1,0 +1,77 @@
+package:
+  name: awscli
+  version: "1.7.34"
+
+source:
+  fn: awscli-1.7.34.tar.gz
+  url: https://pypi.python.org/packages/source/a/awscli/awscli-1.7.34.tar.gz
+  md5: 4328f9565c43be51d049b6cd097c7988
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - awscli = awscli:main
+    #
+    # Would create an entry point called awscli that calls awscli.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - botocore ==1.0.0b3
+    - bcdoc >=0.16.0,<0.17.0
+    - colorama >=0.2.5,<=0.3.3
+    - docutils >=0.10
+    - rsa >=3.1.2,<=3.1.4
+
+  run:
+    - python
+    - botocore ==1.0.0b3
+    - bcdoc >=0.16.0,<0.17.0
+    - colorama >=0.2.5,<=0.3.3
+    - docutils >=0.10
+    - rsa >=3.1.2,<=3.1.4
+
+test:
+  # Python imports
+  imports:
+    - awscli
+    - awscli.customizations
+    - awscli.customizations.codedeploy
+    - awscli.customizations.configservice
+    - awscli.customizations.datapipeline
+    - awscli.customizations.emr
+    - awscli.customizations.s3
+    - awscli.customizations.s3.syncstrategy
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://aws.amazon.com/cli/
+  license: Apache Software License
+  summary: 'Universal Command Line Environment for AWS.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/bcdoc/bld.bat
+++ b/bcdoc/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/bcdoc/build.sh
+++ b/bcdoc/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/bcdoc/meta.yaml
+++ b/bcdoc/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: bcdoc
+  version: "0.16.0"
+
+source:
+  fn: bcdoc-0.16.0.tar.gz
+  url: https://pypi.python.org/packages/source/b/bcdoc/bcdoc-0.16.0.tar.gz
+  md5: e84b506c1c73e71b23d9be0aa00f6bec
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - bcdoc = bcdoc:main
+    #
+    # Would create an entry point called bcdoc that calls bcdoc.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six >=1.8.0,<2.0.0
+    - docutils >=0.10
+
+  run:
+    - python
+    - six >=1.8.0,<2.0.0
+    - docutils >=0.10
+
+test:
+  # Python imports
+  imports:
+    - bcdoc
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/botocore/bcdoc
+  license: Apache Software License
+  summary: 'ReST document generation tools for botocore.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/botocore/bld.bat
+++ b/botocore/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/botocore/build.sh
+++ b/botocore/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/botocore/meta.yaml
+++ b/botocore/meta.yaml
@@ -1,0 +1,76 @@
+package:
+  name: botocore
+  version: "1.0.0b3"
+
+source:
+  fn: botocore-1.0.0b3.tar.gz
+  url: https://pypi.python.org/packages/source/b/botocore/botocore-1.0.0b3.tar.gz
+  md5: fbc663f2ca2979a4b52c9fad15025a2e
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - botocore = botocore:main
+    #
+    # Would create an entry point called botocore that calls botocore.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - jmespath ==0.7.1
+    - bcdoc >=0.16.0,<0.17.0
+    - python-dateutil >=2.1,<3.0.0
+
+  run:
+    - python
+    - jmespath ==0.7.1
+    - bcdoc >=0.16.0,<0.17.0
+    - python-dateutil >=2.1,<3.0.0
+
+test:
+  # Python imports
+  imports:
+    - botocore
+    - botocore.docs
+    - botocore.vendored
+    - botocore.vendored.requests
+    - botocore.vendored.requests.packages
+    - botocore.vendored.requests.packages.chardet
+    - botocore.vendored.requests.packages.urllib3
+    - botocore.vendored.requests.packages.urllib3.contrib
+    - botocore.vendored.requests.packages.urllib3.packages
+    - botocore.vendored.requests.packages.urllib3.packages.ssl_match_hostname
+    - botocore.vendored.requests.packages.urllib3.util
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/boto/botocore
+  license: Apache Software License
+  summary: 'Low-level, data-driven core of boto 3.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/jmespath/bld.bat
+++ b/jmespath/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/jmespath/build.sh
+++ b/jmespath/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/jmespath/meta.yaml
+++ b/jmespath/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: jmespath
+  version: "0.7.1"
+
+source:
+  fn: jmespath-0.7.1.tar.gz
+  url: https://pypi.python.org/packages/source/j/jmespath/jmespath-0.7.1.tar.gz
+  md5: ca76cb014165306c1eded212cfb78cf5
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - jmespath = jmespath:main
+    #
+    # Would create an entry point called jmespath that calls jmespath.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - jmespath
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/jmespath/jmespath.py
+  license: MIT License
+  summary: 'JSON Matching Expressions'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/rsa/bld.bat
+++ b/rsa/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/rsa/build.sh
+++ b/rsa/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/rsa/meta.yaml
+++ b/rsa/meta.yaml
@@ -1,0 +1,78 @@
+package:
+  name: rsa
+  version: "3.1.4"
+
+source:
+  fn: rsa-3.1.4.tar.gz
+  url: https://pypi.python.org/packages/source/r/rsa/rsa-3.1.4.tar.gz
+  md5: b6b1c80e1931d4eba8538fd5d4de1355
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - rsa = rsa:main
+    #
+    # Would create an entry point called rsa that calls rsa.main()
+
+    - pyrsa-priv2pub = rsa.util:private_to_public
+    - pyrsa-keygen = rsa.cli:keygen
+    - pyrsa-encrypt = rsa.cli:encrypt
+    - pyrsa-decrypt = rsa.cli:decrypt
+    - pyrsa-sign = rsa.cli:sign
+    - pyrsa-verify = rsa.cli:verify
+    - pyrsa-encrypt-bigfile = rsa.cli:encrypt_bigfile
+    - pyrsa-decrypt-bigfile = rsa.cli:decrypt_bigfile
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyasn1 >=0.1.3
+
+  run:
+    - python
+    - pyasn1 >=0.1.3
+
+test:
+  # Python imports
+  imports:
+    - rsa
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - pyrsa-priv2pub --help
+    - pyrsa-keygen --help
+    - pyrsa-encrypt --help
+    - pyrsa-decrypt --help
+    - pyrsa-sign --help
+    - pyrsa-verify --help
+    - pyrsa-encrypt-bigfile --help
+    - pyrsa-decrypt-bigfile --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://stuvel.eu/rsa
+  license: Apache Software License
+  summary: 'Pure-Python RSA implementation'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Allows for the AWS command line interface to built/installed within `conda`.

At present, this still does not work because `awscli` fails to properly install the `aws` script in the `bin` directory, which result in something that looks the text below. This problem does not occur when using `pip` with the package. I will need to investigate further to determine the cause.

    #!/opt/anaconda1anaconda2anaconda3/bin/python
    # EASY-INSTALL-SCRIPT: 'awscli==1.7.34','aws'
    __requires__ = 'awscli==1.7.34'
    __import__('pkg_resources').run_script('awscli==1.7.34', 'was')
