### PR TITLE
WIP: Build and install go

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Tell go where it will be installed is not the same as where it is being built.
+export GOROOT_FINAL=$PREFIX
+
+# Change to `src` build and then move out.
+cd src
+./all.bash
+cd ..
+
+# Install everything manually.
+# Note go expects to find `src` for some operations so it **must** be installed.
+test -d bin && mkdir -p $PREFIX/bin && mv bin/* $PREFIX/bin
+test -d include && mkdir -p $PREFIX/include && mv include/* $PREFIX/include
+test -d lib && mkdir -p $PREFIX/lib && mv lib/* $PREFIX/lib
+test -d pkg && mkdir -p $PREFIX/pkg && mv pkg/* $PREFIX/pkg
+test -d sbin && mkdir -p $PREFIX/sbin && mv sbin/* $PREFIX/sbin
+test -d slib && mkdir -p $PREFIX/slib && mv slib/* $PREFIX/slib
+test -d src && mkdir -p $PREFIX/src && mv src/* $PREFIX/src
+rm -rf $PREFIX/doc/go && mkdir -p $PREFIX/doc/go && mv doc/* $PREFIX/doc/go

--- a/go/build.sh
+++ b/go/build.sh
@@ -1,20 +1,14 @@
 #!/bin/bash
 
-# Tell go where it will be installed is not the same as where it is being built.
-export GOROOT_FINAL=$PREFIX
+# Move the go directory into $PREFIX/ so it can be built in its install location.
+cd .. && mv go $PREFIX/ && cd $PREFIX/go
 
 # Change to `src` build and then move out.
 cd src
 ./all.bash
 cd ..
 
-# Install everything manually.
-# Note go expects to find `src` for some operations so it **must** be installed.
-test -d bin && mkdir -p $PREFIX/bin && mv bin/* $PREFIX/bin
-test -d include && mkdir -p $PREFIX/include && mv include/* $PREFIX/include
-test -d lib && mkdir -p $PREFIX/lib && mv lib/* $PREFIX/lib
-test -d pkg && mkdir -p $PREFIX/pkg && mv pkg/* $PREFIX/pkg
-test -d sbin && mkdir -p $PREFIX/sbin && mv sbin/* $PREFIX/sbin
-test -d slib && mkdir -p $PREFIX/slib && mv slib/* $PREFIX/slib
-test -d src && mkdir -p $PREFIX/src && mv src/* $PREFIX/src
-rm -rf $PREFIX/doc/go && mkdir -p $PREFIX/doc/go && mv doc/* $PREFIX/doc/go
+# Link binaries.
+mkdir -p $PREFIX/bin
+ln -s $PREFIX/go/bin/go $PREFIX/bin/go
+ln -s $PREFIX/go/bin/gofmt $PREFIX/bin/gofmt

--- a/go/build.sh
+++ b/go/build.sh
@@ -8,6 +8,9 @@ cd src
 ./all.bash
 cd ..
 
+# Delete `test` directory as it is no longer needed.
+rm -rf test
+
 # Link binaries.
 mkdir -p $PREFIX/bin
 ln -s $PREFIX/go/bin/go $PREFIX/bin/go

--- a/go/hello.go
+++ b/go/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Printf("hello, world\n")
+}

--- a/go/meta.yaml
+++ b/go/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: go
+  version: "1.4.2"
+
+source:
+  fn: go1.4.2.tar.gz
+  url: http://storage.googleapis.com/golang/go1.4.2.src.tar.gz
+  md5: 907f85c8fa765d31f7f955836fec4049
+
+build:
+  number: 0
+
+  detect_binary_files_with_prefix: true
+
+test:
+  files:
+    - hello.go
+
+  commands:
+    - go help
+    # Compile and run a test program. Need to set GOROOT explicitly see topic "Installing to a custom location". ( http://golang.org/doc/install )
+    - GOROOT=$PREFIX go run hello.go
+
+about:
+  home: http://golang.org
+  license: BSD
+  summary: Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

--- a/go/meta.yaml
+++ b/go/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 907f85c8fa765d31f7f955836fec4049
 
 build:
-  number: 1
+  number: 2
 
   binary_relocation: false
 

--- a/go/meta.yaml
+++ b/go/meta.yaml
@@ -8,9 +8,9 @@ source:
   md5: 907f85c8fa765d31f7f955836fec4049
 
 build:
-  number: 0
+  number: 1
 
-  detect_binary_files_with_prefix: true
+  binary_relocation: false
 
 test:
   files:
@@ -19,7 +19,7 @@ test:
   commands:
     - go help
     # Compile and run a test program. Need to set GOROOT explicitly see topic "Installing to a custom location". ( http://golang.org/doc/install )
-    - GOROOT=$PREFIX go run hello.go
+    - go run hello.go
 
 about:
   home: http://golang.org

--- a/go/post-link.sh
+++ b/go/post-link.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Rerun the script to update the paths.
+cd $PREFIX/go/src
+./all.bash

--- a/go/post-link.sh
+++ b/go/post-link.sh
@@ -2,4 +2,4 @@
 
 # Rerun the script to update the paths.
 cd $PREFIX/go/src
-./all.bash
+./make.bash


### PR DESCRIPTION
Installs such that `$GOROOT`=`$PREFIX`. This works and has a test `go` program to verify everything is working once `go` is built. This has been tested on Mac OS 10.9 and CentOS 6.3.
