### PR TITLE
Build with littlecms2 support

### DIFF
--- a/pillow/build.sh
+++ b/pillow/build.sh
@@ -4,6 +4,7 @@ export TIFF_ROOT=$PREFIX
 export JPEG_ROOT=$PREFIX
 export ZLIB_ROOT=$PREFIX
 export FREETYPE2_ROOT=$PREFIX
+export LITTLECMS2_ROOT=$PREFIX
 
 $PYTHON setup.py install
 

--- a/pillow/meta.yaml
+++ b/pillow/meta.yaml
@@ -33,6 +33,7 @@ test:
   imports:
     - PIL
     - PIL.Image
+    - PIL.ImageCms
     - PIL._imagingtk     [linux]
     - PIL._imagingft     [unix]
 

--- a/pillow/run_test.py
+++ b/pillow/run_test.py
@@ -1,4 +1,5 @@
 import PIL
 import PIL.Image
+import PIL.ImageCms
 import PIL._imaging
 import PIL._imagingmath


### PR DESCRIPTION
Pillow has an optional module PIL.ImageCms which is only available when
compiled with littlecms2.

Fixes https://github.com/ContinuumIO/anaconda-issues/issues/371