### PR TITLE
gcc-4.8: Configure with --enable-checking=release

### DIFF
--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -14,6 +14,7 @@ if [ "$(uname)" == "Darwin" ]; then
         --with-cloog=$PREFIX \
         --with-boot-ldflags=$LDFLAGS \
         --with-stage1-ldflags=$LDFLAGS \
+        --enable-checking=release \
         --disable-multilib
 else
     ./configure \
@@ -24,6 +25,7 @@ else
         --with-mpc=$PREFIX \
         --with-isl=$PREFIX \
         --with-cloog=$PREFIX \
+        --enable-checking=release \
         --disable-multilib
 fi
 make

--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 1
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
The [gcc docs][1] say that release binaries are typically configured using `--enable-checking=release`.

[1]: https://gcc.gnu.org/install/configure.html