### PR TITLE
patchelf: uprev to 0.8

### DIFF
--- a/patchelf/meta.yaml
+++ b/patchelf/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: patchelf
-  version: 0.6
+  version: 0.8
 
 source:
   git_url: https://github.com/NixOS/patchelf.git
-  git_tag: 0.6
+  git_tag: 0.8
 
 build:
   number: 0


### PR DESCRIPTION
`patchelf` v0.6 that conda currently uses has a bug that corrupts some (large) `.so` libraries. The symptom is that a library links with apparently no problems, but the produced executable segfaults on load.

The problem goes away with v0.8 (which comes with ~2 years of bugfixes over v0.6, and some extra functionality).