### PR TITLE
yt 3.2

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 3.1.0
+  version: 3.2.0
 
 source:
-  fn: yt-3.1.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-3.1.tar.gz
-  md5: 694235eafbbcd6889f1851dc3170bfb8
+  fn: yt-3.2.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-3.2.tar.gz
+  md5: 1bd2eaa05a06a85c53dee87626454df8
 
 build:
   entry_points:


### PR DESCRIPTION
This updates the yt conda recipe for the 3.2 release.

This release includes single-codebase support for python 3.4 and python 2.7. It would be great if Continuum could build new yt packages for the official anaconda channels for both 2.7 and 3.4. Thanks so much for helping us to distribute yt to conda users!