### PR TITLE
Update Python receipt to 3.5b4

### DIFF
--- a/python-3.5/meta.yaml
+++ b/python-3.5/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python
-  version: 3.5.0b2
+  version: 3.5.0b4
 
 source:
-  fn: Python-3.5.0b2.tar.xz
-  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0b2.tar.xz
-  md5: ef12dce3770032138d83f6159e7d5c3a
+  fn: Python-3.5.0b4.tar.xz
+  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0b4.tar.xz
+  md5: 17a44df9ec94cfb00cad7c57256d4208
 
 build:
   no_link: bin/python


### PR DESCRIPTION
I still get the following error after building:

    $ python
    Python 3.5.0b4 (default, Jul 26 2015, 19:03:29)
    [GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.49)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    Failed calling sys.__interactivehook__
    Traceback (most recent call last):
      File "~/anaconda3/envs/35/lib/python3.5/site.py", line 389, in register_readline
        import rlcompleter
      File "~/anaconda3/envs/35/lib/python3.5/rlcompleter.py", line 161, in <module>
        readline.set_completer(Completer().complete)
    AttributeError: module 'readline' has no attribute 'set_completer'
    >>>

And either `--with-ensurepip=no` in build script or `$ conda metapackage pip 7.0.3 --dependencies 'python 3.5*'` is needed for this to build correctly (have to check which one).