### PR TITLE
ggplot fixes - pin version, cleanup recipe, add missing dependencies

### DIFF
--- a/ggplot/bld.bat
+++ b/ggplot/bld.bat
@@ -1,2 +1,8 @@
-python setup.py install
+"%PYTHON%" setup.py install
 if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/ggplot/build.sh
+++ b/ggplot/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-${PYTHON} setup.py install || exit 1;
+$PYTHON setup.py install
 
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/ggplot/meta.yaml
+++ b/ggplot/meta.yaml
@@ -29,6 +29,7 @@ source:
 requirements:
   build:
     - python
+    - mock
     - setuptools
     - six
     - statsmodels
@@ -41,6 +42,7 @@ requirements:
 
   run:
     - python
+    - mock
     - six
     - statsmodels
     - brewer2mpl

--- a/ggplot/meta.yaml
+++ b/ggplot/meta.yaml
@@ -1,44 +1,86 @@
-
 package:
-    name: ggplot
-    version: "master"
+  name: ggplot
+  version: "0.6.5"
 
 source:
-    git_url: https://github.com/yhat/ggplot
-    git_tag: "master"
+  fn: ggplot-0.6.5.tar.gz
+  url: https://pypi.python.org/packages/source/g/ggplot/ggplot-0.6.5.tar.gz
+  md5: c825f9ca48bc9b12c2e2517c7f8b9538
+#  patches:
+   # List any patch files here
+   # - fix.patch
 
-build:
-    number: 0
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ggplot = ggplot:main
+    #
+    # Would create an entry point called ggplot that calls ggplot.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
 
 requirements:
-    build:
-        - python
-        - setuptools
-        - matplotlib
-        - pandas
-        - numpy
-        - scipy
-        - statsmodels
-        - patsy
-        - brewer2mpl
-        - husl
+  build:
+    - python
+    - setuptools
+    - six
+    - statsmodels
+    - brewer2mpl
+    - matplotlib
+    - scipy
+    - patsy
+    - pandas
+    - numpy
 
-    run:
-        - python
-        - matplotlib
-        - pandas
-        - numpy
-        - scipy
-        - statsmodels
-        - patsy
-        - brewer2mpl
-        - husl
+  run:
+    - python
+    - six
+    - statsmodels
+    - brewer2mpl
+    - matplotlib
+    - scipy
+    - patsy
+    - pandas
+    - numpy
 
 test:
-    imports:
-        - ggplot
+  # Python imports
+  imports:
+    - ggplot
+    - ggplot.components
+    - ggplot.coords
+    - ggplot.exampledata
+    - ggplot.geoms
+    - ggplot.scales
+    - ggplot.stats
+    - ggplot.tests
+    - ggplot.themes
+    - ggplot.utils
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
 
 about:
-    home: https://github.com/yhat/ggplot/
-    license: BSD
+  home: https://github.com/yhat/ggplot/
+  license: BSD
+  summary: 'ggplot for python'
 
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/ggplot/meta.yaml
+++ b/ggplot/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   build:
     - python
     - mock
+    - nose
     - setuptools
     - six
     - statsmodels
@@ -43,6 +44,7 @@ requirements:
   run:
     - python
     - mock
+    - nose
     - six
     - statsmodels
     - brewer2mpl


### PR DESCRIPTION
* Initially built from source. Now, builds from a PyPI version.
* Recipe format cleaned up to match `conda skeleton pypi` format.
* Added `mock` and `nose` as dependencies as `ggplot` installs its tests. Without these, the recipe will fail to build.