### PR TITLE
update swig

### DIFF
--- a/swig/meta.yaml
+++ b/swig/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: swig
-  version: 3.0.5
+  version: 3.0.6
 
 source:
-  fn: swig-3.0.5.tar.gz
-  url: http://prdownloads.sourceforge.net/swig/swig-3.0.5.tar.gz
-  md5: dcb9638324461b9baba8e044fe59031d
+  fn: swig-3.0.6.tar.gz
+  url: http://prdownloads.sourceforge.net/swig/swig-3.0.6.tar.gz
+  md5: df43ae271642bcfa61c1e59f970f9963
 
 build:
   detect_binary_files_with_prefix: True


### PR DESCRIPTION
v3.0.6 has a lot of python fixes including a regression fix from 3.0.2:
https://github.com/swig/swig/blob/master/CHANGES