### PR TITLE
 ipython_memwatcher: Adds the iPython memory watcher for simpler profiling of iPython notebook cells.

### DIFF
--- a/ipython_memwatcher/bld.bat
+++ b/ipython_memwatcher/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/ipython_memwatcher/bld.bat
+++ b/ipython_memwatcher/bld.bat
@@ -1,8 +1,2 @@
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/ipython_memwatcher/build.sh
+++ b/ipython_memwatcher/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
 $PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.

--- a/ipython_memwatcher/build.sh
+++ b/ipython_memwatcher/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/ipython_memwatcher/meta.yaml
+++ b/ipython_memwatcher/meta.yaml
@@ -6,24 +6,8 @@ source:
   fn: ipython_memwatcher-0.2.1.tar.gz
   url: https://pypi.python.org/packages/source/i/ipython_memwatcher/ipython_memwatcher-0.2.1.tar.gz
   md5: 2b266a05e22825f8e3676ec341e3861f
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
 build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - ipython_memwatcher = ipython_memwatcher:main
-    #
-    # Would create an entry point called ipython_memwatcher that calls ipython_memwatcher.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
   number: 0
 
 requirements:
@@ -39,27 +23,10 @@ requirements:
     - memory_profiler
 
 test:
-  # Python imports
   imports:
     - ipython_memwatcher
-
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: https://github.com/FrancescAlted/ipython_memwatcher
   license: BSD 2-Clause
   summary: 'ipython_memwatcher: display memory usage during IPython execution'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/ipython_memwatcher/meta.yaml
+++ b/ipython_memwatcher/meta.yaml
@@ -1,0 +1,65 @@
+package:
+  name: ipython_memwatcher
+  version: "0.2.1"
+
+source:
+  fn: ipython_memwatcher-0.2.1.tar.gz
+  url: https://pypi.python.org/packages/source/i/ipython_memwatcher/ipython_memwatcher-0.2.1.tar.gz
+  md5: 2b266a05e22825f8e3676ec341e3861f
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ipython_memwatcher = ipython_memwatcher:main
+    #
+    # Would create an entry point called ipython_memwatcher that calls ipython_memwatcher.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - ipython >=2.1
+    - memory_profiler
+
+  run:
+    - python
+    - ipython >=2.1
+    - memory_profiler
+
+test:
+  # Python imports
+  imports:
+    - ipython_memwatcher
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/FrancescAlted/ipython_memwatcher
+  license: BSD 2-Clause
+  summary: 'ipython_memwatcher: display memory usage during IPython execution'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/ipython_memwatcher/meta.yaml
+++ b/ipython_memwatcher/meta.yaml
@@ -10,7 +10,7 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
+build:
   # noarch_python: True
   # preserve_egg_dir: True
   # entry_points:
@@ -24,7 +24,7 @@ source:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Closes conda/conda-recipes#363.