### PR TITLE
HDF5 1.8.14

### DIFF
--- a/h5py/meta.yaml
+++ b/h5py/meta.yaml
@@ -17,6 +17,7 @@ source:
 
 requirements:
   build:
+    - python
     - numpy
     - hdf5         [unix]
     - cython       [unix]
@@ -27,5 +28,5 @@ requirements:
     - unittest2    [py26]
 
 about:
-  home: http://code.google.com/p/h5py/
+  home: http://www.h5py.org/
   license: New BSD (http://opensource.org/licenses/bsd-license.php)

--- a/hdf5/meta.yaml
+++ b/hdf5/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: hdf5
-  version: 1.8.13
+  version: 1.8.14
 
 source:
-  fn: hdf5-1.8.13.tar.bz2
-  url: http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.13/src/hdf5-1.8.13.tar.bz2
-  md5: b060bb137d6bd8accf8f0c4c59d2746d
+  fn: hdf5-1.8.14.tar.bz2
+  url: http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.14/src/hdf5-1.8.14.tar.bz2
+  md5: 719df6d46eea52e42dd97d59dcbf5311
 
 build:
   number: 0


### PR DESCRIPTION
Closes conda/conda-recipes#232.

Rebased the old PR.

Testing...

Builds on OSX 10.9
Builds on CentOS 6.3