### PR TITLE
Improved GCC 4.8 package

### DIFF
--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -52,13 +52,8 @@ else
         --disable-multilib
 fi
 make -j"$CPU_COUNT"
-make install
+make install-strip
 rm "$PREFIX"/lib64
-
-# Strip debug symbols from binaries to minify the package
-if [ "$(uname)" == "Linux" ]; then
-    find "$PREFIX" -perm /u=x,g=x,o=x -type f -exec strip --strip-debug {} \; || true
-fi
 
 # Link cc to gcc
 (cd "$PREFIX"/bin && ln -s gcc cc)

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -51,9 +51,14 @@ else
         --with-tune=generic \
         --disable-multilib
 fi
-make -j$CPU_COUNT
+make -j"$CPU_COUNT"
 make install
 rm "$PREFIX"/lib64
+
+# Strip debug symbols from binaries to minify the package
+if [ "$(uname)" == "Linux" ]; then
+    find "$PREFIX" -perm /u=x,g=x,o=x -type f -exec strip --strip-debug {} \; || true
+fi
 
 # Link cc to gcc
 (cd "$PREFIX"/bin && ln -s gcc cc)

--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/gcc-4.8/notes.md
+++ b/gcc-4.8/notes.md
@@ -1,4 +1,13 @@
-This requires a newish gcc to build. gcc 4.7 will work.
+Tools that are necessary for building GCC:
+https://gcc.gnu.org/install/prerequisites.html
+
+This package is known to be able to build on CentOS 5.11 with gcc 4.1.2.
+The Docker centos:5.11 image was used and the following packages installed:
+
+* required to unpack GCC sources:
+    tar bzip2
+* required to build GCC:
+    gcc gcc-c++ make zip
 
 We do not require gcc as a build dependency because we want to make sure that
 conda build finds all the files installed for this gcc when creating the

--- a/libgcc/meta.yaml
+++ b/libgcc/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: libgcc
   version: 4.8.5
 
+build:
+  number: 3
+
 requirements:
   build:
     - gcc 4.8.5

--- a/libgcc/meta.yaml
+++ b/libgcc/meta.yaml
@@ -5,13 +5,6 @@ package:
 requirements:
   build:
     - gcc 4.8.5
-  run:
-    # I'm unsure if these are all still needed but it doesn't hurt to have them.
-    - gmp >=4.2
-    - mpfr >=2.4.0
-    - mpc >=0.8.0
-    - isl
-    - cloog 0.18.0
 
 build:
   always_include_files:


### PR DESCRIPTION
Added a step to strip debug symbols on Linux that makes the package 60% smaller (860MB -> 290MB unpacked and 280MB -> 78MB tar.bz2).

libgcc package had unnecessary run dependencies.

This pull request was inspired by #279 