### PR TITLE
Add Python 3 support for Boost package

### DIFF
--- a/boost/build.sh
+++ b/boost/build.sh
@@ -22,6 +22,8 @@ if [ "$(uname)" == "Darwin" ]; then
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \
+        --with-python="${PYTHON}" \
+        --with-icu="${PREFIX}" \
         | tee bootstrap.log 2>&1
 
     ./b2 -q \

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -8,36 +8,54 @@
 # Hints for OSX:
 # http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
 
-mkdir -vp ${PREFIX}/bin;
+set -x -e
 
-if [ `uname` == Darwin ]; then
+if [ "$(uname)" == "Darwin" ]; then
     MACOSX_VERSION_MIN=10.8
     CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
     CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
     LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN} "
-    LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -L${LIBRARY_PATH}"
+    LINKFLAGS="${LINKFLAGS} -stdlib=libc++"
 
     ./bootstrap.sh \
-      --prefix="${PREFIX}/" --libdir="${PREFIX}/lib/" \
-      | tee bootstrap.log 2>&1
+        --prefix="${PREFIX}" \
+        | tee bootstrap.log 2>&1
 
     ./b2 \
-      variant=release address-model=64 architecture=x86 \
-      threading=multi link=shared toolset=clang include=${INCLUDE_PATH} \
-      cxxflags="${CXXFLAGS}" linkflags="${LINKFLAGS}" \
-      -j$(sysctl -n hw.ncpu) \
-      install | tee b2.log 2>&1
+        variant=release \
+        address-model=64 \
+        architecture=x86 \
+        threading=multi \
+        link=shared \
+        toolset=clang \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        -j"$(sysctl -n hw.ncpu)" \
+        install | tee b2.log 2>&1
 fi
 
-if [ `uname` == Linux ]; then
-  ./bootstrap.sh \
-    --prefix="${PREFIX}/" --libdir="${PREFIX}/lib/" \
-    | tee bootstrap.log 2>&1
+if [ "$(uname)" == "Linux" ]; then
+    ./bootstrap.sh \
+        --prefix="${PREFIX}" \
+        --with-python="${PYTHON}" \
+        --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
+        --with-icu="${PREFIX}" \
+        | tee bootstrap.log 2>&1
 
-  ./b2 \
-    variant=release address-model=${ARCH} architecture=x86 \
-    threading=multi link=shared toolset=gcc include=${INCLUDE_PATH} \
-    -j${CPU_COUNT} \
-    install | tee b2.log 2>&1
+    ./b2 -q -d0 \
+        variant=release \
+        address-model="${ARCH}" \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        runtime-link=shared \
+        link=shared,static \
+        toolset=gcc \
+        python="${PY_VER}" \
+        cflags="-O3 -I${PREFIX}/include" \
+        cxxflags="-O3 -I${PREFIX}/include" \
+        linkflags="-L${PREFIX}/lib" \
+        --layout=system \
+        -j"${CPU_COUNT}" \
+        install | tee b2.log 2>&1
 fi
-

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -1,10 +1,11 @@
 package:
   name: boost
-  version: 1.58.0
+  version: 1.59.0
 
 source:
-  fn: boost_1_58_0.tar.bz2
-  url: http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
+  fn: boost_1_59_0.tar.bz2
+  url: http://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.tar.bz2
+  md5: 6aa9a5c6a4ca1016edd0ed1178e3cb87
 
 build:
   number: 4

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: boost
-  version: 1.57.0
+  version: 1.58.0
 
 source:
-  fn: boost_1_57_0.tar.bz2
-  url: http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.bz2
+  fn: boost_1_58_0.tar.bz2
+  url: http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2
 
 build:
   number: 4
@@ -17,6 +17,8 @@ requirements:
     - libpython         [win]
 
   run:
+    # python dependency is here due to libboost-python library that depends on python version
+    - python
     - icu               [unix]
 
 about:


### PR DESCRIPTION
- [x] Added support of Python 3 (It has to be built in Python 2 and Python 3 environments now.)
- [x] Fixed some configuration options for OS X and Linux.
- [x] Upgraded to 1.58.0
- [x] Tested on CentOS 6.6, Ubuntu 14.04, OS X
- [x] Add `icu` support for OS X