### PR TITLE
Adds recipe to build pylibtiff

### DIFF
--- a/pylibtiff/build.sh
+++ b/pylibtiff/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+python setup.py install --prefix=$PREFIX
+ESC_PREFIX=$(python -c "print(\"${PREFIX}\".replace(\"/\", \"\\/\"))")
+NEWLINE=$'\n'
+sed -i.bak "s/if os.name=='nt':/os.environ[\"LD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"LD_LIBRARY_PATH\", \"\")\\${NEWLINE}os.environ[\"DYLD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"DYLD_LIBRARY_PATH\", \"\")\\${NEWLINE}if os.name=='nt':/g" $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py
+rm $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py.bak

--- a/pylibtiff/build.sh
+++ b/pylibtiff/build.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+if [[ `uname` == 'Darwin' ]]; then
+    DYLIB_EXT=dylib
+else
+    DYLIB_EXT=so
+fi
+
+
 python setup.py install --prefix=$PREFIX
 ESC_PREFIX=$(python -c "print(\"${PREFIX}\".replace(\"/\", \"\\/\"))")
 NEWLINE=$'\n'

--- a/pylibtiff/build.sh
+++ b/pylibtiff/build.sh
@@ -10,9 +10,5 @@ fi
 
 
 python setup.py install --prefix=$PREFIX
-ESC_PREFIX=$(python -c "print(\"${PREFIX}\".replace(\"/\", \"\\/\"))")
-NEWLINE=$'\n'
-sed -i.bak "s/if os.name=='nt':/os.environ[\"LD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"LD_LIBRARY_PATH\", \"\")\\${NEWLINE}os.environ[\"DYLD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"DYLD_LIBRARY_PATH\", \"\")\\${NEWLINE}if os.name=='nt':/g" $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py
-rm $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py.bak
 
 ln -s $PREFIX/lib/libtiff.$DYLIB_EXT $SP_DIR/libtiff/libtiff.$DYLIB_EXT

--- a/pylibtiff/build.sh
+++ b/pylibtiff/build.sh
@@ -8,7 +8,5 @@ else
     DYLIB_EXT=so
 fi
 
-
 python setup.py install --prefix=$PREFIX
-
 ln -s $PREFIX/lib/libtiff.$DYLIB_EXT $SP_DIR/libtiff/libtiff.$DYLIB_EXT

--- a/pylibtiff/build.sh
+++ b/pylibtiff/build.sh
@@ -14,3 +14,5 @@ ESC_PREFIX=$(python -c "print(\"${PREFIX}\".replace(\"/\", \"\\/\"))")
 NEWLINE=$'\n'
 sed -i.bak "s/if os.name=='nt':/os.environ[\"LD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"LD_LIBRARY_PATH\", \"\")\\${NEWLINE}os.environ[\"DYLD_LIBRARY_PATH\"] = \"${ESC_PREFIX}\/lib:\" + os.environ.get(\"DYLD_LIBRARY_PATH\", \"\")\\${NEWLINE}if os.name=='nt':/g" $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py
 rm $PREFIX/lib/python2.7/site-packages/libtiff/libtiff_ctypes.py.bak
+
+ln -s $PREFIX/lib/libtiff.$DYLIB_EXT $SP_DIR/libtiff/libtiff.$DYLIB_EXT

--- a/pylibtiff/libtiff_ctypes.py.patch
+++ b/pylibtiff/libtiff_ctypes.py.patch
@@ -1,0 +1,26 @@
+diff --git libtiff/libtiff_ctypes.py libtiff/libtiff_ctypes.py
+index e4d48bf..fd02a32 100644
+--- libtiff/libtiff_ctypes.py
++++ libtiff/libtiff_ctypes.py
+@@ -37,10 +37,18 @@ else:
+         lib = '../Frameworks/libtiff.dylib'
+     else:
+         lib = ctypes.util.find_library('tiff')
+-if lib is None:
+-    raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
+ 
+-libtiff = ctypes.cdll.LoadLibrary(lib)
++libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
++if libtiff is None:
++    try:
++        if sys.platform == "darwin":
++            libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
++        elif "win" in sys.platform:
++            libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
++        else:
++            libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
++    except OSError:
++        raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
+ 
+ libtiff.TIFFGetVersion.restype = ctypes.c_char_p
+ libtiff.TIFFGetVersion.argtypes = []

--- a/pylibtiff/libtiff_ctypes.py.patch
+++ b/pylibtiff/libtiff_ctypes.py.patch
@@ -1,26 +1,65 @@
 diff --git libtiff/libtiff_ctypes.py libtiff/libtiff_ctypes.py
-index e4d48bf..fd02a32 100644
+index e4d48bf..8dc4486 100644
 --- libtiff/libtiff_ctypes.py
 +++ libtiff/libtiff_ctypes.py
-@@ -37,10 +37,18 @@ else:
-         lib = '../Frameworks/libtiff.dylib'
-     else:
-         lib = ctypes.util.find_library('tiff')
+@@ -21,26 +21,41 @@ import ctypes.util
+ import struct
+ import collections
+ 
+-if os.name=='nt':
+-    # assume that the directory of libtiff3.dll is in PATH.
+-    lib = ctypes.util.find_library('libtiff3')
+-    if lib is None:
+-        # try default installation path:
+-        lib = r'C:\Program Files\GnuWin32\bin\libtiff3.dll'
+-        if os.path.isfile (lib):
+-            print 'You should add %r to PATH environment variable and reboot.' % (os.path.dirname (lib))
+-        else:
+-            lib = None
+-else:
+-    if hasattr(sys, 'frozen') and sys.platform == 'darwin' and os.path.exists('../Frameworks/libtiff.dylib'):
+-        # py2app support, see Issue 8.
+-        lib = '../Frameworks/libtiff.dylib'
+-    else:
+-        lib = ctypes.util.find_library('tiff')
 -if lib is None:
 -    raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
  
 -libtiff = ctypes.cdll.LoadLibrary(lib)
-+libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
-+if libtiff is None:
-+    try:
-+        if sys.platform == "darwin":
-+            libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
-+        elif "win" in sys.platform:
-+            libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
++cwd = os.getcwd()
++try:
++    os.chdir(os.path.dirname(__file__))
++
++    if os.name=='nt':
++        # assume that the directory of libtiff3.dll is in PATH.
++        lib = ctypes.util.find_library('libtiff3')
++        if lib is None:
++            # try default installation path:
++            lib = r'C:\Program Files\GnuWin32\bin\libtiff3.dll'
++            if os.path.isfile (lib):
++                print 'You should add %r to PATH environment variable and reboot.' % (os.path.dirname (lib))
++            else:
++                lib = None
++    else:
++        if hasattr(sys, 'frozen') and sys.platform == 'darwin' and os.path.exists('../Frameworks/libtiff.dylib'):
++            # py2app support, see Issue 8.
++            lib = '../Frameworks/libtiff.dylib'
 +        else:
-+            libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
-+    except OSError:
-+        raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
++            lib = ctypes.util.find_library('tiff')
++
++    libtiff = None if lib is None else ctypes.cdll.LoadLibrary(lib)
++    if libtiff is None:
++        try:
++            if sys.platform == "darwin":
++                libtiff = ctypes.cdll.LoadLibrary("libtiff.dylib")
++            elif "win" in sys.platform:
++                libtiff = ctypes.cdll.LoadLibrary("libtiff.dll")
++            else:
++                libtiff = ctypes.cdll.LoadLibrary("libtiff.so")
++        except OSError:
++            raise ImportError('Failed to find TIFF library. Make sure that libtiff is installed and its location is listed in PATH|LD_LIBRARY_PATH|..')
++finally:
++    os.chdir(cwd)
  
  libtiff.TIFFGetVersion.restype = ctypes.c_char_p
  libtiff.TIFFGetVersion.argtypes = []

--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: pylibtiff
+  version: 0.4.0
+
+source:
+  fn: pylibtiff.tar.gz
+  url: https://pypi.python.org/packages/source/l/libtiff/libtiff-0.4.0.tar.gz
+  md5: f7cad14620548b21bf05a276a040f487
+
+requirements:
+  build:
+    - python
+    - numpy
+    - libtiff
+  run:
+    - python
+    - numpy
+    - libtiff
+
+test:
+  requires:
+    - nose
+  imports:
+    - libtiff
+
+about:
+  home: https://github.com/pearu/pylibtiff
+  license: BSD

--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -6,6 +6,8 @@ source:
   fn: pylibtiff.tar.gz
   url: https://pypi.python.org/packages/source/l/libtiff/libtiff-0.4.0.tar.gz
   md5: f7cad14620548b21bf05a276a040f487
+  patches:
+    - libtiff_ctypes.py.patch
 
 requirements:
   build:

--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -19,6 +19,9 @@ requirements:
     - numpy
     - libtiff
 
+build:
+  number: 1
+
 test:
   requires:
     - nose


### PR DESCRIPTION
This works on both Mac and Linux. It was tested on Mac OS 10.9 and CentOS 6.3.

This is patched to simplify finding `libtiff`. This patch is being submitted as a PR ( https://github.com/pearu/pylibtiff/pull/36 ).