### PR TITLE
Switch from using `gcc` to `libgcc` as a runtime requirement

### DIFF
--- a/tig/meta.yaml
+++ b/tig/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - gcc
   run:
     - ncurses
-    - gcc
+    - libgcc
 
 test:
   commands:


### PR DESCRIPTION
I tried to get everything using `gcc` as a runtime dependency to use `libgcc` instead. It turned out only one package was doing this.