### PR TITLE
colorlog: new package

### DIFF
--- a/colorlog/bld.bat
+++ b/colorlog/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/colorlog/build.sh
+++ b/colorlog/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/colorlog/meta.yaml
+++ b/colorlog/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: colorlog
+  version: "2.6.0"
+
+source:
+  fn: colorlog-2.6.0.tar.gz
+  url: https://pypi.python.org/packages/source/c/colorlog/colorlog-2.6.0.tar.gz
+  md5: 38c23018fff88653dfdaafb984c8d0fa
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - colorama [win]
+
+  run:
+    - python
+    - colorama [win]
+
+test:
+  imports:
+    - colorlog
+
+about:
+  home: https://github.com/borntyping/python-colorlog
+  license: MIT License
+  summary: 'Log formatting with colors!'


### PR DESCRIPTION
It allows colors to be placed in the format logging string, which is mostly useful when paired with a StreamHandler that is outputting to a terminal. This is accomplished by added a set of terminal color codes to the record before it is used to format the string.

Details about the package are here: https://github.com/borntyping/python-colorlog