### PR TITLE
invoke: new package

### DIFF
--- a/invoke/bld.bat
+++ b/invoke/bld.bat
@@ -7,7 +7,7 @@ if "%PY_VER%" == "2.7" rmdir /S /Q "invoke\vendor\yaml3"
 else rmdir /S /Q "invoke\vendor\yaml2"
 
 :: Workaround conda-build issue #251: https://github.com/conda/conda-build/issues/251
-ECHO "program_run = program.run">>invoke\main.py
+ECHO program_run = program.run >>"invoke\main.py"
 
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1

--- a/invoke/bld.bat
+++ b/invoke/bld.bat
@@ -2,6 +2,7 @@
 :: has yaml for Python3 codebase, which fails on Python2.
 :: Related question on conda-build issue tracker:
 :: https://github.com/conda/conda-build/pull/317#commitcomment-12926020
+:: WARNING: this has to be removed when noarch_python is enabled!
 if "%PY_VER%" == "2.7" rmdir /S /Q "invoke\vendor\yaml3"
 
 "%PYTHON%" setup.py install

--- a/invoke/bld.bat
+++ b/invoke/bld.bat
@@ -1,0 +1,14 @@
+:: conda-build tries to compile .pyc files in Python 2 environment, but Invoke
+:: has yaml for Python3 codebase, which fails on Python2.
+:: Related question on conda-build issue tracker:
+:: https://github.com/conda/conda-build/pull/317#commitcomment-12926020
+if "%PY_VER%" == "2.7" rmdir /S /Q "invoke\vendor\yaml3"
+
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/invoke/bld.bat
+++ b/invoke/bld.bat
@@ -4,6 +4,10 @@
 :: https://github.com/conda/conda-build/pull/317#commitcomment-12926020
 :: WARNING: this has to be removed when noarch_python is enabled!
 if "%PY_VER%" == "2.7" rmdir /S /Q "invoke\vendor\yaml3"
+else rmdir /S /Q "invoke\vendor\yaml2"
+
+:: Workaround conda-build issue #251: https://github.com/conda/conda-build/issues/251
+ECHO "program_run = program.run">>invoke\main.py
 
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1

--- a/invoke/build.sh
+++ b/invoke/build.sh
@@ -12,4 +12,7 @@ else
     rm -rf invoke/vendor/yaml2
 fi
 
+# Workaround conda-build issue #251: https://github.com/conda/conda-build/issues/251
+echo "program_run = program.run" >> invoke/main.py
+
 $PYTHON setup.py install

--- a/invoke/build.sh
+++ b/invoke/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# conda-build tries to compile .pyc files in Python 2 environment, but Invoke
+# has yaml for Python3 codebase, which fails on Python2.
+# Related question on conda-build issue tracker:
+# https://github.com/conda/conda-build/pull/317#commitcomment-12926020
+if [[ "${PY_VER%%.*}" == "2" ]]; then
+    rm -rf invoke/vendor/yaml3
+fi
+
+$PYTHON setup.py install

--- a/invoke/build.sh
+++ b/invoke/build.sh
@@ -4,6 +4,7 @@
 # has yaml for Python3 codebase, which fails on Python2.
 # Related question on conda-build issue tracker:
 # https://github.com/conda/conda-build/pull/317#commitcomment-12926020
+# WARNING: this has to be removed when noarch_python is enabled!
 if [[ "${PY_VER%%.*}" == "2" ]]; then
     rm -rf invoke/vendor/yaml3
 fi

--- a/invoke/build.sh
+++ b/invoke/build.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# conda-build tries to compile .pyc files in Python 2 environment, but Invoke
-# has yaml for Python3 codebase, which fails on Python2.
-# Related question on conda-build issue tracker:
-# https://github.com/conda/conda-build/pull/317#commitcomment-12926020
-# WARNING: this has to be removed when noarch_python is enabled!
 if [[ "${PY_VER%%.*}" == "2" ]]; then
+    # conda-build tries to compile .pyc files in Python 2 environment, but
+    # Invoke has yaml for Python3 codebase, which fails on Python2.
+    # Related question on conda-build issue tracker:
+    # https://github.com/conda/conda-build/pull/317#commitcomment-12926020
+    # WARNING: this has to be removed when noarch_python is enabled!
     rm -rf invoke/vendor/yaml3
+else
+    # Python 3.5+ doesn't support syntax of old Python 2.x exceptions either.
+    rm -rf invoke/vendor/yaml2
 fi
 
 $PYTHON setup.py install

--- a/invoke/meta.yaml
+++ b/invoke/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: invoke
+  version: {{ environ.get('GIT_DESCRIBE_TAG', 'current') }}
+
+source:
+  git_url: https://github.com/pyinvoke/invoke.git
+
+build:
+  noarch_python: true
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  entry_points:
+    - invoke = invoke.cli:main
+    - inv = invoke.cli:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - invoke
+
+  commands:
+    - invoke --help
+    - inv --help
+
+about:
+  home: https://github.com/pyinvoke/invoke/
+  license: BSD License
+  summary: |
+    Invoke is a Python (2.6+ and 3.2+) task execution tool & library, drawing
+    inspiration from various sources to arrive at a powerful & clean feature
+    set.

--- a/invoke/meta.yaml
+++ b/invoke/meta.yaml
@@ -11,8 +11,9 @@ build:
   #noarch_python: true
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   entry_points:
-    - invoke = invoke.main:program.run
-    - inv = invoke.main:program.run
+    # Workaround conda-build issue #251: https://github.com/conda/conda-build/issues/251
+    - invoke = invoke.main:program_run
+    - inv = invoke.main:program_run
 
 requirements:
   build:

--- a/invoke/meta.yaml
+++ b/invoke/meta.yaml
@@ -11,8 +11,8 @@ build:
   #noarch_python: true
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   entry_points:
-    - invoke = invoke.cli:main
-    - inv = invoke.cli:main
+    - invoke = invoke.main:program.run
+    - inv = invoke.main:program.run
 
 requirements:
   build:

--- a/invoke/meta.yaml
+++ b/invoke/meta.yaml
@@ -6,7 +6,9 @@ source:
   git_url: https://github.com/pyinvoke/invoke.git
 
 build:
-  noarch_python: true
+  # There is still an issue with noarch_python packages. Such packages cannot be installed from
+  # repositories due to the bug: https://github.com/conda/conda/issues/1391
+  #noarch_python: true
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   entry_points:
     - invoke = invoke.cli:main


### PR DESCRIPTION
Invoke is a Python (2.6+ and 3.3+) task execution tool & library, drawing inspiration from various sources to arrive at a powerful & clean feature set.

It is a future part of Fabric 2.0. Though it still hasn't reached release state, it works fine enough for us and many other DevOps.
