### PR TITLE
gcc-4.8: Fix default include path for system headers

### DIFF
--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -11,7 +11,6 @@ ln -s "$PREFIX/lib" "$PREFIX/lib64"
 
 if [ "$(uname)" == "Darwin" ]; then
     export LDFLAGS="-Wl,-headerpad_max_install_names"
-    export BOOT_LDFLAGS="-Wl,-headerpad_max_install_names"
     export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib"
 
     ./configure \

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -12,6 +12,7 @@ ln -s "$PREFIX/lib" "$PREFIX/lib64"
 if [ "$(uname)" == "Darwin" ]; then
     export LDFLAGS="-Wl,-headerpad_max_install_names"
     export BOOT_LDFLAGS="-Wl,-headerpad_max_install_names"
+    export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib"
 
     ./configure \
         --prefix="$GCC_PREFIX" \

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -10,8 +10,10 @@ mkdir "$GCC_PREFIX"
 ln -s "$PREFIX/lib" "$PREFIX/lib64"
 
 if [ "$(uname)" == "Darwin" ]; then
-    export LDFLAGS="-Wl,-headerpad_max_install_names"
-    export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib"
+    # On Mac, we expect that the user has installed the xcode command-line utilities (via the 'xcode-select' command).
+    # The system's libstdc++.6.dylib will be located in /usr/lib, and we need to help the gcc build find it.
+    export LDFLAGS="-Wl,-headerpad_max_install_names -Wl,-L${PREFIX}/lib -Wl,-L/usr/lib"
+    export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib:/usr/lib"
 
     ./configure \
         --prefix="$GCC_PREFIX" \
@@ -24,8 +26,8 @@ if [ "$(uname)" == "Darwin" ]; then
         --with-mpc="$PREFIX" \
         --with-isl="$PREFIX" \
         --with-cloog="$PREFIX" \
-        --with-boot-ldflags=$LDFLAGS \
-        --with-stage1-ldflags=$LDFLAGS \
+        --with-boot-ldflags="$LDFLAGS" \
+        --with-stage1-ldflags="$LDFLAGS" \
         --enable-checking=release \
         --with-tune=generic \
         --disable-multilib

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -1,3 +1,12 @@
+# Install gcc to its very own prefix.
+# GCC must not be installed to the same prefix as the environment,
+# because $GCC_PREFIX/include is automatically considered to be a
+# "system" header path.
+# That could cause -I$PREFIX/include to be essentially ignored in users' recipes
+# (It would still be on the search path, but it would be in the wrong position in the search order.)
+GCC_PREFIX="$PREFIX/gcc"
+mkdir "$GCC_PREFIX"
+
 ln -s "$PREFIX/lib" "$PREFIX/lib64"
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -5,7 +14,10 @@ if [ "$(uname)" == "Darwin" ]; then
     export BOOT_LDFLAGS="-Wl,-headerpad_max_install_names"
 
     ./configure \
-        --prefix="$PREFIX" \
+        --prefix="$GCC_PREFIX" \
+        --with-gxx-include-dir="$GCC_PREFIX/include/c++" \
+        --bindir="$PREFIX/bin" \
+        --datarootdir="$PREFIX/share" \
         --libdir="$PREFIX/lib" \
         --with-gmp="$PREFIX" \
         --with-mpfr="$PREFIX" \
@@ -23,7 +35,10 @@ else
     mkdir -p "${PREFIX}/share"
     cat /etc/*-release > "${PREFIX}/share/conda-gcc-build-machine-os-details"
     ./configure \
-        --prefix="$PREFIX" \
+        --prefix="$GCC_PREFIX" \
+        --with-gxx-include-dir="$GCC_PREFIX/include/c++" \
+        --bindir="$PREFIX/bin" \
+        --datarootdir="$PREFIX/share" \
         --libdir="$PREFIX"/lib \
         --with-gmp="$PREFIX" \
         --with-mpfr="$PREFIX" \

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -15,6 +15,7 @@ if [ "$(uname)" == "Darwin" ]; then
         --with-boot-ldflags=$LDFLAGS \
         --with-stage1-ldflags=$LDFLAGS \
         --enable-checking=release \
+        --with-tune=generic \
         --disable-multilib
 else
     # For reference during post-link.sh, record some
@@ -30,6 +31,7 @@ else
         --with-isl="$PREFIX" \
         --with-cloog="$PREFIX" \
         --enable-checking=release \
+        --with-tune=generic \
         --disable-multilib
 fi
 make -j$CPU_COUNT

--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 1 # [linux32]
+  number: 2
 
 requirements:
   build:

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -108,8 +108,8 @@ else
         #
         # With these two lines:
         # *cpp:
-        # ... yada yada ... -I${INCDIR}
-        sed -i ':a;N;$!ba;s|\(*cpp:\n[^\n]*\)|\1 -I'${INCDIR}'|g' "${SPECS_FILE}"
+        # ... yada yada ... -isystem ${INCDIR}
+        sed -i ':a;N;$!ba;s|\(*cpp:\n[^\n]*\)|\1 -isystem '${INCDIR}'|g' "${SPECS_FILE}"
     done
 fi
 

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -95,7 +95,7 @@ else
     # First create specs file from existing defaults
     SPECS_DIR=$(echo "${PREFIX}"/lib/gcc/*/*)
     SPECS_FILE="${SPECS_DIR}/specs"
-    gcc -dumpspecs > "${SPECS_FILE}"
+    "${PREFIX}"/bin/gcc -dumpspecs > "${SPECS_FILE}"
 
     # Now add extra include paths to the specs file, one at a time.
     # (So far we only know of one: from Ubuntu.)

--- a/gcc-4.8/run_test.sh
+++ b/gcc-4.8/run_test.sh
@@ -41,6 +41,12 @@ fi
 # Execute the compiled output.
 (
     set -e
+    if [ "$(uname)" == "Darwin" ]; then
+        # On Mac, compiled executables need help finding libstdc++.dylib
+        # (When building a recipe, conda-build will fix up the dylib links internally,
+        #  so this isn't necesary in recipes.)
+        DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib"
+    fi
     ./hello_c.out > /dev/null
     ./hello_cpp.out > /dev/null
 )


### PR DESCRIPTION
There is a critical problem with conda's gcc package, which this PR addresses.

**tl;dr**: If we install gcc to `$PREFIX`, then gcc automatically considers `$PREFIX/include` to be a "system" header path.  That can mess up the include order.  This PR installs gcc to a special place (`$PREFIX/gcc`) to avoid the problem.

**Background:**

As we all know, when gcc searches for a header file, it searches any paths the user provided via `-I`, and then gcc also searches an internal list of "system" directories.  In general, the user's directories are searched in the same order as the user's `-I` arguments. But if the user supplies a `-I` argument that happens to *already* be on gcc's internal "system" include path, then that particular `-I` argument is ignored -- it's a system directory, and system directories are always searched last.  (See gcc docs: https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html)

**The problem:**

When building gcc, the `--prefix` configure argument specifies the installation directory.  As it turns out, gcc **automatically adds** `$(prefix)/include` to its internal "system" include path. [1]  Since conda's gcc recipe `--prefix=$PREFIX`, the environment's `$PREFIX/include` directory is considered to be a *system* directory by gcc.

\[1\]: The [gcc configuration docs](https://gcc.gnu.org/install/configure.html) say:
>Both the local-prefix include directory and the GCC-prefix include directory are part of GCC's “system include” directories.

**Why is that bad?**

Now the user can't control the include order properly.  In my case, an old version of a library (say, hdf5) happened to be installed in `/usr/local/include`.  Ordinarily, it shouldn't cause any problems because I passed `-I $PREFIX/include` to the compiler, so my hdf5 headers in `$PREFIX/include` should be found first and used in my program.  But since gcc thinks `$PREFIX/include` is a system header, my `-I` argument is ignored, and that directory is searched last.  The outdated hdf5 headers in `/usr/local/include` were found first, and my recipe didn't compile properly.

**The Fix:**

gcc can be configured to install its files in custom install locations for `lib`, `bin`, `share`, etc., but apparently `include` cannot be separately controlled.  The only way to change the installation `include` directory is to change the entire install prefix.  In this PR, instead of `--prefix=$PREFIX`, I use `--prefix=$PREFIX/gcc`.  Then, to maintain compatibility with existing recipes, I also provide extra configure args to make sure that `bin`, `lib`, etc. stay in the same locations they had previously.  Only the gcc headers have moved.

**Addendum:**

While I was at it, I fixed some other minor issues with the `gcc` package.  I could have opened separate PRs for those, but in the past it's been easier to consider multiple changes at once (gcc is tedious to compile).