### PR TITLE
gsl - use system compiler instead of Anaconda gcc.

### DIFF
--- a/gsl/build.sh
+++ b/gsl/build.sh
@@ -1,4 +1,4 @@
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --with-pic
 
 make -j ${CPU_COUNT}
 make check

--- a/gsl/build.sh
+++ b/gsl/build.sh
@@ -1,5 +1,5 @@
 ./configure --prefix=$PREFIX
 
-make
+make -j ${CPU_COUNT}
 make check
 make install

--- a/gsl/meta.yaml
+++ b/gsl/meta.yaml
@@ -4,15 +4,11 @@ package:
 
 source:
   fn: gsl-1.16.tar.gz
-  url: http://ftp.club.cc.cmu.edu/pub/gnu/gsl/gsl-1.16.tar.gz
+  url: http://ftpmirror.gnu.org/gsl/gsl-1.16.tar.gz
+  sha256: 73bc2f51b90d2a780e6d266d43e487b3dbd78945dd0b04b14ca5980fe28d2f53
 
 build:
-  number: 2 # [osx]
-  number: 1 # [linux]
-
-requirements:
-  build:
-    - gcc
+  number: 3
 
 about:
   home: http://www.gnu.org/software/gsl/

--- a/gsl/meta.yaml
+++ b/gsl/meta.yaml
@@ -8,7 +8,7 @@ source:
   sha256: 73bc2f51b90d2a780e6d266d43e487b3dbd78945dd0b04b14ca5980fe28d2f53
 
 build:
-  number: 3
+  number: 4
 
 about:
   home: http://www.gnu.org/software/gsl/


### PR DESCRIPTION
gsl package should either require libgcc in its run dependencies or not use the Anaconda gcc at all.