### PR TITLE
Scotch recipe now also search in conda library dir and conda include dir.

### DIFF
--- a/scotch/build.sh
+++ b/scotch/build.sh
@@ -6,14 +6,15 @@ echo 'prefix = $PREFIX' > Makefile.inc
 echo '' >> Makefile.inc
 if [ `uname` == "Darwin" ]; then
   cat Make.inc/Makefile.inc.x86-64_pc_linux2 | \
-    sed -e "s/-lz -lm -lrt/-lz -lm/" | \
-    sed -e "s/-DSCOTCH_PTHREAD//" | \
-    sed -e "s/-DCOMMON_PTHREAD//" | \
-    sed -e "s/= -O3/= -fPIC -O3/" >> \
+    sed -e "s|-lz -lm -lrt|-lz -lm -L$PREFIX/lib|" | \
+    sed -e "s|-DSCOTCH_PTHREAD||" | \
+    sed -e "s|-DCOMMON_PTHREAD||" | \
+    sed -e "s|= -O3|= -fPIC -O3 -I$PREFIX/include|" >> \
     Makefile.inc
 else
-  cat Make.inc/Makefile.inc.x86-64_pc_linux2 | \
-    sed -e "s/= -O3/= -fPIC -O3/" >> \
+    cat Make.inc/Makefile.inc.x86-64_pc_linux2 | \
+    sed -e "s|= -O3|= -pthread -fPIC -O3 -I$PREFIX/include|" | \
+    sed -e "s|-lz -lm -lrt|-lz -lm -L$PREFIX/lib|" >> \
     Makefile.inc
 fi
 make | tee make.log 2>&1

--- a/scotch/meta.yaml
+++ b/scotch/meta.yaml
@@ -15,3 +15,7 @@ build:
 about:
   home: http://www.labri.fr/perso/pelegrin/scotch/
   license: CeCILL-C
+
+requirements:
+  build:
+    - zlib


### PR DESCRIPTION
This allow to build recipe using conda libz instead of system libz.
Add libz as build dependency
