### PR TITLE
Ensure graphviz is properly configured

### DIFF
--- a/graphviz/build.sh
+++ b/graphviz/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # see http://conda.pydata.org/docs/build.html for hacking instructions.
 
-export CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
+export CFLAGS="-Wall -g -m${ARCH} -pipe -O2 -fPIC"
 export CXXLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"

--- a/graphviz/build.sh
+++ b/graphviz/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # see http://conda.pydata.org/docs/build.html for hacking instructions.
 
-export CFLAGS="-Wall -g -m64 -pipe -O2 -march=x86-64 -fPIC"
+export CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
 export CXXLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"

--- a/graphviz/meta.yaml
+++ b/graphviz/meta.yaml
@@ -10,7 +10,7 @@ source:
      - gvconfig_libdir.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:

--- a/graphviz/post-link.sh
+++ b/graphviz/post-link.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 
-dot -c
+$PREFIX/bin/dot -c

--- a/graphviz/post-link.sh
+++ b/graphviz/post-link.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+dot -c


### PR DESCRIPTION
* Runs `dot -c` as a post-link step to properly find all runtime dependencies.
* Also, ensures architecture can be specified and isn't forced to be 64-bit.