### PR TITLE
gcc-5: Fix default include path for system headers (ported from gcc-4.8 package)

### DIFF
--- a/gcc-5/build.sh
+++ b/gcc-5/build.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 
+# Install gcc to its very own prefix.
+# GCC must not be installed to the same prefix as the environment,
+# because $GCC_PREFIX/include is automatically considered to be a
+# "system" header path.
+# That could cause -I$PREFIX/include to be essentially ignored in users' recipes
+# (It would still be on the search path, but it would be in the wrong position in the search order.)
+GCC_PREFIX="$PREFIX/gcc"
+mkdir "$GCC_PREFIX"
+
 ln -s "$PREFIX/lib" "$PREFIX/lib64"
 
 if [ "$(uname)" == "Darwin" ]; then
-    export DYLD_LIBRARY_PATH="$PREFIX/lib/"
-    export LDFLAGS="-Wl,-headerpad_max_install_names"
-    export BOOT_LDFLAGS="-Wl,-headerpad_max_install_names"
+    # On Mac, we expect that the user has installed the xcode command-line utilities (via the 'xcode-select' command).
+    # The system's libstdc++.6.dylib will be located in /usr/lib, and we need to help the gcc build find it.
+    export LDFLAGS="-Wl,-headerpad_max_install_names -Wl,-L${PREFIX}/lib -Wl,-L/usr/lib"
+    export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib:/usr/lib"
 
     ./configure \
-        --prefix="$PREFIX" \
+        --prefix="$GCC_PREFIX" \
+        --with-gxx-include-dir="$GCC_PREFIX/include/c++" \
+        --bindir="$PREFIX/bin" \
+        --datarootdir="$PREFIX/share" \
         --libdir="$PREFIX/lib" \
         --with-gmp="$PREFIX" \
         --with-mpfr="$PREFIX" \
@@ -18,6 +31,7 @@ if [ "$(uname)" == "Darwin" ]; then
         --with-boot-ldflags="$LDFLAGS" \
         --with-stage1-ldflags="$LDFLAGS" \
         --enable-checking=release \
+        --with-tune=generic \
         --disable-multilib
 else
     # For reference during post-link.sh, record some
@@ -25,14 +39,18 @@ else
     mkdir -p "${PREFIX}/share"
     cat /etc/*-release > "${PREFIX}/share/conda-gcc-build-machine-os-details"
     ./configure \
-        --prefix="$PREFIX" \
-        --libdir="$PREFIX/lib" \
+        --prefix="$GCC_PREFIX" \
+        --with-gxx-include-dir="$GCC_PREFIX/include/c++" \
+        --bindir="$PREFIX/bin" \
+        --datarootdir="$PREFIX/share" \
+        --libdir="$PREFIX"/lib \
         --with-gmp="$PREFIX" \
         --with-mpfr="$PREFIX" \
         --with-mpc="$PREFIX" \
         --with-isl="$PREFIX" \
         --with-cloog="$PREFIX" \
         --enable-checking=release \
+        --with-tune=generic \
         --disable-multilib
 fi
 make -j"$CPU_COUNT"

--- a/gcc-5/meta.yaml
+++ b/gcc-5/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/gcc-5/post-link.sh
+++ b/gcc-5/post-link.sh
@@ -95,7 +95,7 @@ else
     # First create specs file from existing defaults
     SPECS_DIR=$(echo "${PREFIX}"/lib/gcc/*/*)
     SPECS_FILE="${SPECS_DIR}/specs"
-    gcc -dumpspecs > "${SPECS_FILE}"
+    "${PREFIX}"/bin/gcc -dumpspecs > "${SPECS_FILE}"
 
     # Now add extra include paths to the specs file, one at a time.
     # (So far we only know of one: from Ubuntu.)
@@ -108,8 +108,8 @@ else
         #
         # With these two lines:
         # *cpp:
-        # ... yada yada ... -I${INCDIR}
-        sed -i ':a;N;$!ba;s|\(*cpp:\n[^\n]*\)|\1 -I'${INCDIR}'|g' "${SPECS_FILE}"
+        # ... yada yada ... -isystem ${INCDIR}
+        sed -i ':a;N;$!ba;s|\(*cpp:\n[^\n]*\)|\1 -isystem '${INCDIR}'|g' "${SPECS_FILE}"
     done
 fi
 

--- a/gcc-5/run_test.sh
+++ b/gcc-5/run_test.sh
@@ -41,6 +41,12 @@ fi
 # Execute the compiled output.
 (
     set -e
+    if [ "$(uname)" == "Darwin" ]; then
+        # On Mac, compiled executables need help finding libstdc++.dylib
+        # (When building a recipe, conda-build will fix up the dylib links internally,
+        #  so this isn't necesary in recipes.)
+        DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib"
+    fi
     ./hello_c.out > /dev/null
     ./hello_cpp.out > /dev/null
 )


### PR DESCRIPTION
Ported PR #401 to GCC 5.x package.