### PR TITLE
Qt recipes now use CPU_COUNT

### DIFF
--- a/qt/build.sh
+++ b/qt/build.sh
@@ -28,6 +28,7 @@ if [ `uname` == Linux ]; then
     # See https://bugreports.qt.io/browse/QTBUG-5385
     LD_LIBRARY_PATH=$SRC_DIR/lib make -j $CPU_COUNT
     
+    make -j${CPU_COUNT}
     make install
 
     cp $SRC_DIR/bin/* $PREFIX/bin/
@@ -53,7 +54,7 @@ if [ `uname` == Darwin ]; then
         -opensource -verbose -openssl -no-framework -system-libpng \
         -arch `uname -m` -L $PREFIX/lib -I $PREFIX/include
 
-    make -j $(sysctl -n hw.ncpu)
+    make -j ${CPU_COUNT}
     make install
 fi
 

--- a/qt5/build.sh
+++ b/qt5/build.sh
@@ -20,8 +20,6 @@ if [ `uname` == Darwin ]; then
     CONFIG_OPTS+=" -platform macx-g++ -no-framework -no-c++11"
     CONFIG_OPTS+=" -no-mtdev -no-harfbuzz -no-xinput2 -no-xcb-xlib"
     CONFIG_OPTS+=" -no-libudev -no-egl"
-
-    MAKE_JOBS=$(sysctl -n hw.ncpu)
 fi
 
 chmod +x configure
@@ -42,7 +40,7 @@ chmod +x configure
             -qt-zlib \
             $CONFIG_OPTS
 
-make -j $MAKE_JOBS
+make -j ${CPU_COUNT}
 make install
 
 for file in $PREFIX/lib/qt5/bin/*


### PR DESCRIPTION
Qt recipes now use CPU_COUNT variable everywhere instead of "sysctl -n hw.ncpu"
