### PR TITLE
Incremented numpy-openblas to numpy 1.10.0

### DIFF
--- a/numpy-openblas/meta.yaml
+++ b/numpy-openblas/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: numpy
-  version: 1.9.2
+  version: 1.10.0
 
 source:
-  fn: numpy-1.9.2.tar.gz
-  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.9.2.tar.gz
-  md5: a1ed53432dbcd256398898d35bc8e645
+  fn: numpy-1.10.0.tar.gz
+  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.10.0.tar.gz
+  md5: 116c65ae392e9b50aad713f42158f32a
 
 requirements:
   build:


### PR DESCRIPTION
Recipe built successfully on Yosemite + miniconda + py35.  Behold the future:


```
In [6]: A = np.eye(3)

In [7]: x = np.arange(3)

In [8]: A@x
Out[8]: array([ 0.,  1.,  2.])
```