### PR TITLE
Separate test data from matplotlib package

### DIFF
--- a/matplotlib-tests/bld.bat
+++ b/matplotlib-tests/bld.bat
@@ -1,1 +1,1 @@
-xcopy lib\matplotlib\tests %SP_DIR%\matplotlib /S
+move lib\matplotlib\tests %SP_DIR%\matplotlib\

--- a/matplotlib-tests/bld.bat
+++ b/matplotlib-tests/bld.bat
@@ -1,0 +1,1 @@
+xcopy lib\matplotlib\tests %SP_DIR%\matplotlib /S

--- a/matplotlib-tests/build.sh
+++ b/matplotlib-tests/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp -r lib/matplotlib/tests $SP_DIR/matplotlib/

--- a/matplotlib-tests/meta.yaml
+++ b/matplotlib-tests/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: matplotlib-tests
+  version: 1.5.0
+
+source:
+  git_url: https://github.com/matplotlib/matplotlib.git
+  git_rev: v1.5.x
+
+requirements:
+  build:
+    - matplotlib ==1.5.0
+
+  run:
+    - matplotlib ==1.5.0
+
+about:
+  home: http://matplotlib.sourceforge.net/
+  license: PSF-based (http://matplotlib.sourceforge.net/users/license.html)

--- a/matplotlib-tests/meta.yaml
+++ b/matplotlib-tests/meta.yaml
@@ -15,6 +15,15 @@ requirements:
   run:
     - matplotlib =={{ version }}
 
+  test:
+  requires:
+    - nose
+    - mock
+    - matplotlib
+
+  imports:
+    - matplotlib
+
 about:
   home: http://matplotlib.sourceforge.net/
   license: PSF-based (http://matplotlib.sourceforge.net/users/license.html)

--- a/matplotlib-tests/meta.yaml
+++ b/matplotlib-tests/meta.yaml
@@ -1,6 +1,8 @@
+{% set version = '1.5.0' %}
+
 package:
   name: matplotlib-tests
-  version: 1.5.0
+  version: {{ version }}
 
 source:
   git_url: https://github.com/matplotlib/matplotlib.git
@@ -8,10 +10,10 @@ source:
 
 requirements:
   build:
-    - matplotlib ==1.5.0
+    - matplotlib =={{ version }}
 
   run:
-    - matplotlib ==1.5.0
+    - matplotlib =={{ version }}
 
 about:
   home: http://matplotlib.sourceforge.net/

--- a/matplotlib-tests/meta.yaml
+++ b/matplotlib-tests/meta.yaml
@@ -5,8 +5,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/matplotlib/matplotlib.git
-  git_rev: v1.5.x
+  fn: matplotlib-1.5.0.tar.gz
+  url: https://pypi.python.org/packages/source/m/matplotlib/matplotlib-1.5.0.tar.gz
+  md5: 7952a539418ed77432aa4727409f24cf
 
 requirements:
   build:

--- a/matplotlib-tests/run_test.py
+++ b/matplotlib-tests/run_test.py
@@ -1,0 +1,2 @@
+import matplotlib
+matplotlib.test()

--- a/matplotlib/cfg_notests.patch
+++ b/matplotlib/cfg_notests.patch
@@ -1,0 +1,13 @@
+diff --git setup.cfg.template setup.cfg.template
+index 09fd92f..2085832 100644
+--- setup.cfg.template
++++ setup.cfg.template
+@@ -18,7 +18,7 @@
+ # optional.  They are all installed by default, but they may be turned
+ # off here.
+ #
+-#tests = True
++tests = False
+ #sample_data = True
+ #toolkits = True
+ # Tests for the toolkits are only automatically installed

--- a/matplotlib/meta.yaml
+++ b/matplotlib/meta.yaml
@@ -44,7 +44,7 @@ requirements:
 test:
   requires:
     - nose
-    - matplotlib-tests
+    - mock
 
 about:
   home: http://matplotlib.sourceforge.net/

--- a/matplotlib/meta.yaml
+++ b/matplotlib/meta.yaml
@@ -3,8 +3,9 @@ package:
   version: 1.5.0
 
 source:
-  git_url: https://github.com/matplotlib/matplotlib.git
-  git_rev: v1.5.x
+  fn: matplotlib-1.5.0.tar.gz
+  url: https://pypi.python.org/packages/source/m/matplotlib/matplotlib-1.5.0.tar.gz
+  md5: 7952a539418ed77432aa4727409f24cf
 
   patches:
     - setupext.patch

--- a/matplotlib/meta.yaml
+++ b/matplotlib/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: matplotlib
-  version: 1.4.3
+  version: 1.5.0
 
 source:
-  fn: matplotlib-1.4.3.tar.gz
-  url: https://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.4.3/matplotlib-1.4.3.tar.gz
-  md5: 67a28a359af4919896d1ec74b6e6b3ce
+  git_url: https://github.com/matplotlib/matplotlib.git
+  git_rev: v1.5.x
 
   patches:
     - setupext.patch
     - cfg.patch
+    - cfg_notests.patch
     - cfg_qt4agg.patch    [not osx]
     - rctmp_pyside.patch  [not osx]
     - osx-tk.patch        [osx]
@@ -21,7 +21,6 @@ requirements:
     - numpy
     - python-dateutil
     - freetype
-    - nose
     - pyparsing
     - pytz
     - py2cairo            [linux and py2k]
@@ -29,6 +28,8 @@ requirements:
     - libpng
     - zlib                [win]
     - pyqt                [not osx]
+    - cycler
+
   run:
     - python
     - numpy
@@ -39,6 +40,11 @@ requirements:
     - py2cairo            [linux and py2k]
     - libpng              [unix]
     - pyqt                [not osx]
+
+test:
+  requires:
+    - nose
+    - matplotlib-tests
 
 about:
   home: http://matplotlib.sourceforge.net/

--- a/matplotlib/run_test.py
+++ b/matplotlib/run_test.py
@@ -25,3 +25,5 @@ if int(os.getenv('GUI_TEST', 0)):
     plt.title('If this window displays, success: CLOSE TO CONTINUE TESTS')
     plt.plot([1,2,5,9])
     plt.show()
+
+matplotlib.test()

--- a/matplotlib/run_test.py
+++ b/matplotlib/run_test.py
@@ -25,5 +25,3 @@ if int(os.getenv('GUI_TEST', 0)):
     plt.title('If this window displays, success: CLOSE TO CONTINUE TESTS')
     plt.plot([1,2,5,9])
     plt.show()
-
-matplotlib.test()


### PR DESCRIPTION
matplotlib includes almost 36MB of compressed test data, and most users won't need it.  This separates out matplotlib from the test data, in a new package called "matplotlib-tests".

This is my first real foray into conda packaging, so I may not have done some things correctly.

The upcoming matplotlib 1.5 release will behave normally if the test data is not installed (you just can't run the tests).  I've set this to git URLs for now, but obviously I'll change that to a regular old tarball once a release has been made and before this is merged.  I'd just like to get feedback on this approach in advance of the matplotlib release in case this will require further changes on matplotlib's end.