### PR TITLE
Pin `pylibtiff`'s version of `libtiff` to 4.0.3 or less

### DIFF
--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -12,15 +12,15 @@ source:
 requirements:
   build:
     - python
-    - numpy
+    - numpy 1.9.*
     - libtiff <=4.0.3
   run:
     - python
-    - numpy
+    - numpy 1.9.*
     - libtiff <=4.0.3
 
 build:
-  number: 2
+  number: 3
 
 test:
   requires:

--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -12,15 +12,15 @@ source:
 requirements:
   build:
     - python
-    - numpy 1.9.*
+    - numpy
     - libtiff <=4.0.3
   run:
     - python
-    - numpy 1.9.*
+    - numpy
     - libtiff <=4.0.3
 
 build:
-  number: 3
+  number: 2
 
 test:
   requires:

--- a/pylibtiff/meta.yaml
+++ b/pylibtiff/meta.yaml
@@ -13,14 +13,14 @@ requirements:
   build:
     - python
     - numpy
-    - libtiff
+    - libtiff <=4.0.3
   run:
     - python
     - numpy
-    - libtiff
+    - libtiff <=4.0.3
 
 build:
-  number: 1
+  number: 2
 
 test:
   requires:


### PR DESCRIPTION
`pylibtiff` doesn't currently have support for a release of `libtiff` later that 4.0.3. So, pin it such that it doesn't use a later release.