### PR TITLE
add netifaces

### DIFF
--- a/netifaces/bld.bat
+++ b/netifaces/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" -m pip install --no-use-wheel --ignore-installed .
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/netifaces/build.sh
+++ b/netifaces/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON -m pip install --no-use-wheel --ignore-installed .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/netifaces/meta.yaml
+++ b/netifaces/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: netifaces
+  version: "0.10.4"
+
+source:
+  fn: netifaces-0.10.4.tar.gz
+  url: https://pypi.python.org/packages/source/n/netifaces/netifaces-0.10.4.tar.gz
+  md5: 36da76e2cfadd24cc7510c2c0012eb1e
+
+requirements:
+  build:
+    - python
+    - pip
+
+  run:
+    - python
+
+test:
+  imports:
+    - netifaces
+
+  commands:
+    - python -c "import netifaces; [ netifaces.ifaddresses(iface) for iface in netifaces.interfaces() ]"
+
+about:
+  home: https://bitbucket.org/al45tair/netifaces
+  license: MIT License
+  summary: 'Portable network interface information.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
used by jupyter-client. This is a simple conda-skeleton-pypi package, onlg ensuring that it is installed with pip instead of setup.py, since it unconditionally imports setuptools.

How do we get things like this into official conda packages?