### PR TITLE
Fix VTK package on OS X

### DIFF
--- a/vtk/apple.patch
+++ b/vtk/apple.patch
@@ -1,0 +1,10 @@
+diff -ur a/CMakeLists.txt b/CMakeLists.txt
+--- CMakeLists.txt	2015-09-01 15:41:26.000000000 -0600
++++ CMakeLists.txt	2015-10-20 14:46:28.000000000 -0600
+@@ -599,3 +599,6 @@
+       "without manually building the 'VTKData' target.")
+   endif()
+ endif()
++if(APPLE)
++  set(EXECUTABLE_FLAG MACOSX_BUNDLE)
++endif(APPLE)

--- a/vtk/meta.yaml
+++ b/vtk/meta.yaml
@@ -7,9 +7,10 @@ source:
   fn:  vtk-6.3.0.tar.gz
   patches:
     - dlls.patch                              [win]
+    - apple.patch                             [osx]
 
 build:
-  number: 1                                   [linux]
+  number: 1                                   [not win]
   has_prefix_files:                           [win]
     - Lib/site-packages/vtk/__init__.py       [win]
 


### PR DESCRIPTION
For those of us only using the Command Line Tools (CLT).

It would appear conda arbitrarily setting MACOSX_DEPLOYMENT_TARGET to 10.6, assumes one has the Xcode SDK installed.

I was able to determine; There is only one place where Command Line Tools can be installed. And if the user's environment indeed has their development path set to the CLT path... then lets drop the SDK requirement.

The included patch file is to make application bundles work on OS X. See VTK's explination here: http://www.vtk.org/Wiki/Cocoa_VTK#Use_Application_Bundles