### PR TITLE
Add pysparselm and sparselm packages

### DIFF
--- a/pysparselm/build.sh
+++ b/pysparselm/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/sh
+
+sed -i -e 's/fpic/fPIC/' setup.py
+export CC="gcc -fPIC"
+$PYTHON setup.py build build_ext -I$PREFIX/include/splm/ -L$PREFIX/lib64/ -lsplm
+$PYTHON setup.py install

--- a/pysparselm/meta.yaml
+++ b/pysparselm/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: pysparselm
+  version: 0.1.0
+
+source:
+  fn: pysparselm-0.1.0.zip
+  url: http://www.bmp.ds.mpg.de/pysparselm.html?file=tl_files/bmp/software/pysparselm/pysparselm-0.1.0.zip
+  sha1: 5c2de661a976967fd329bc456c0a90ab0d80fdc4
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+    - sparselm
+
+  run:
+    - python
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - pysparselm
+
+about:
+  home: http://www.bmp.ds.mpg.de/pysparselm.html
+  license: GPL
+  summary: Sparse non-linear least-squares solver (Python-bindings to sparselm)

--- a/sparselm/build.sh
+++ b/sparselm/build.sh
@@ -9,4 +9,6 @@ cmake                              \
     ..
 make
 mkdir -p $PREFIX/lib64
+mkdir -p $PREFIX/include/splm
 cp libsplm.a $PREFIX/lib64/
+cp ../*.h $PREFIX/include/splm/

--- a/sparselm/build.sh
+++ b/sparselm/build.sh
@@ -1,0 +1,11 @@
+mkdir build
+cd build
+
+cmake                              \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DBUILD_DEMO=OFF               \
+    -DCHOLMOD_INCDIR=/usr/include/suitesparse \
+    ..
+make
+mkdir -p $PREFIX/lib64
+cp libsplm.a $PREFIX/lib64/

--- a/sparselm/build.sh
+++ b/sparselm/build.sh
@@ -5,6 +5,7 @@ cmake                              \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DBUILD_DEMO=OFF               \
     -DCHOLMOD_INCDIR=/usr/include/suitesparse \
+    -DCMAKE_C_FLAGS="-fPIC" \
     ..
 make
 mkdir -p $PREFIX/lib64

--- a/sparselm/meta.yaml
+++ b/sparselm/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: sparselm
+  version: 1.3
+
+source:
+  fn: sparselm-1.3.tgz
+  url: http://users.ics.forth.gr/~lourakis/sparseLM/sparselm-1.3.tgz
+  sha1: 3e2157b0d964522b313e874fe2f7a1ca30528c58
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - cmake
+
+about:
+  home: http://users.ics.forth.gr/~lourakis/sparseLM/
+  license: GPL
+  summary: Sparse non-linear least-squares solver


### PR DESCRIPTION
pysparselm is a Python wrapper for the sparselm library.
Sparselm solves sparse non-linear least-squares problems.

The packages have been tested on Fedora 22 x64.
The sparselm package requires that the "suitesparse" package is installed.
