### PR TITLE
aubio/meta.yaml: depend on numpy version

### DIFF
--- a/aubio/meta.yaml
+++ b/aubio/meta.yaml
@@ -12,10 +12,10 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy
+    - numpy x.x
   run:
     - python
-    - numpy
+    - numpy x.x
 
 test:
   commands:


### PR DESCRIPTION
This adds x.x to numpy so that package gets build against current CONDA_NPY version. 