### PR TITLE
update git to 2.6.2; build without tcltk (no GUI)

### DIFF
--- a/git/build.sh
+++ b/git/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 make configure
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --without-tcltk
 make all
 make install
 

--- a/git/build.sh
+++ b/git/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# NOTE: On Ubuntu, compilation required installation of autoconf and gettext from apt-get
+
 make configure
-CFLAGS="$CFLAGS -m64" CPPFLAGS="$CPPFLAGS -I$PREFIX/include" LDFLAGS="$LDFLAGS -L$PREFIX/lib" ./configure --prefix=$PREFIX --without-tcltk
+if [ $ARCH == 64 ]; then
+    CFLAGS="$CFLAGS -m64" CPPFLAGS="$CPPFLAGS -I$PREFIX/include" LDFLAGS="$LDFLAGS -L$PREFIX/lib" ./configure --prefix=$PREFIX --without-tcltk
+else
+    CPPFLAGS="$CPPFLAGS -I$PREFIX/include" LDFLAGS="$LDFLAGS -L$PREFIX/lib" ./configure --prefix=$PREFIX --without-tcltk
+fi
 make all
 make install
 

--- a/git/build.sh
+++ b/git/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 make configure
-./configure --prefix=$PREFIX --without-tcltk
+CFLAGS="$CFLAGS -m64" CPPFLAGS="$CPPFLAGS -I$PREFIX/include" LDFLAGS="$LDFLAGS -L$PREFIX/lib" ./configure --prefix=$PREFIX --without-tcltk
 make all
 make install
 

--- a/git/meta.yaml
+++ b/git/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 2.6.2
 
 source:
-  git_url: git@github.com:git/git.git
+  git_url: https://github.com/git/git.git
   git_tag: v2.6.2
 
 requirements:

--- a/git/meta.yaml
+++ b/git/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: git
-  version: 2.4.6
+  version: 2.6.2
 
 source:
   git_url: git@github.com:git/git.git
-  git_tag: v2.4.6
+  git_tag: v2.6.2
 
 requirements:
   build:


### PR DESCRIPTION
TclTk was causing problems with Mac packaging.  I think it was a dumb path escaping issue: the Git GUI app name has a space in it.

This also forces the build to use our builds of zlib and openssl, rather than any system versions.  The -m64 flag might need special-casing in an ARCH statement.