### PR TITLE
Added jbig

### DIFF
--- a/jbig/Makefile.patch
+++ b/jbig/Makefile.patch
@@ -1,0 +1,11 @@
+--- Makefile	2014-03-27 14:47:15.000000000 -0400
++++ Makefile	2015-11-06 14:14:48.000000000 -0500
+@@ -4,7 +4,7 @@
+ CC = gcc
+ 
+ # Options for the compiler: A high optimization level is suggested
+-CFLAGS = -O2 -W -Wno-unused-result
++CFLAGS = -O2 -W -fPIC
+ # CFLAGS = -O -g -W -Wall -Wno-unused-result -ansi -pedantic # -DDEBUG
+ 
+ export CC CFLAGS

--- a/jbig/build.sh
+++ b/jbig/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Patch (support old gcc)
+sed -i.bak 's/-Wno-unused-result//g' Makefile
+
+# Build
+make lib
+
+# Install
+mkdir -p "${PREFIX}/lib" "${PREFIX}/include"
+cp libjbig/*.a "${PREFIX}/lib"
+cp libjbig/*.h "${PREFIX}/include"

--- a/jbig/meta.yaml
+++ b/jbig/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: jbig
+  version: "2.1"
+
+source:
+  fn: jbigkit-2.1.tar.gz
+  url: https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/jbigkit-2.1.tar.gz
+  md5: ebcf09bed9f14d7fa188d3bd57349522
+  
+  patches:
+    - Makefile.patch # Remove -Wno-unused-result (for compatibility with old gcc),
+                     # and add -fPIC (to allow shared libraries to use this build).
+
+about:
+  home: https://www.cl.cam.ac.uk/~mgk25/jbigkit
+  license: GPL-2


### PR DESCRIPTION
Added a recipe for JBIG-KIT library: https://www.cl.cam.ac.uk/~mgk25/jbigkit/
(No Windows support in this recipe.)
You can download a pre-built copy of this recipe via `conda install -c stuarteberg jbig.`
