### PR TITLE
Don’t require user interaction in PyQt4 and PyQt5 tests

### DIFF
--- a/pyqt/run_test.py
+++ b/pyqt/run_test.py
@@ -1,10 +1,11 @@
 # From http://zetcode.com/gui/pyqt4/firstprograms/
 import sys
 from PyQt4 import QtGui
+from PyQt4.QtCore import QTimer
 
 
 def main():
-    
+
     app = QtGui.QApplication(sys.argv)
 
     w = QtGui.QWidget()
@@ -12,7 +13,16 @@ def main():
     w.move(300, 300)
     w.setWindowTitle('Simple')
     w.show()
-    
+
+    def quit_app():
+        app.quit()
+
+    close_timer = QTimer()
+    close_timer.setInterval(5000)
+    close_timer.setSingleShot(True)
+    close_timer.timeout.connect(quit_app)
+    close_timer.start()
+
     sys.exit(app.exec_())
 
 

--- a/pyqt5/run_test.py
+++ b/pyqt5/run_test.py
@@ -2,10 +2,11 @@
 
 import sys
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import QTimer
 
 
 def main():
-    
+
     app = QtWidgets.QApplication(sys.argv)
 
     w = QtWidgets.QWidget()
@@ -13,7 +14,16 @@ def main():
     w.move(300, 300)
     w.setWindowTitle('Simple Test')
     w.show()
-    
+
+    def quit_app():
+        app.quit()
+
+    close_timer = QTimer()
+    close_timer.setInterval(5000)
+    close_timer.setSingleShot(True)
+    close_timer.timeout.connect(quit_app)
+    close_timer.start()
+
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
I want to be able to run ``conda build`` in an automated way for PyQt5, but currently the test requires user interaction. With this change, the window auto-closes after 5 seconds.

cc @ccordoba12 (author of the original test)