### PR TITLE
Update yt to 3.2.2

### DIFF
--- a/yt/meta.yaml
+++ b/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 3.2.1
+  version: 3.2.2
 
 source:
-  fn: yt-3.2.1.tar.gz
-  url: https://pypi.python.org/packages/source/y/yt/yt-3.2.1.tar.gz
-  md5: 5cda4af043d4a9fd557877bfbb29b3e2
+  fn: yt-3.2.2.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-3.2.2.tar.gz
+  sha1: e9e907dea0124fbb99a0b3291854ae7307b244ad
 
 build:
   entry_points:


### PR DESCRIPTION
This is a regularly scheduled bugfix release. We'd appreciate it if Continuum could build packages for python2.7 and python3.4. Python3.5 support should also be doable but we don't have CI set up for that yet so it might be premature to set up conda packages.

Thanks for your help distributing yt!

