### PR TITLE
Improve boost recipe on Linux and Mac

### DIFF
--- a/boost/bld.bat
+++ b/boost/bld.bat
@@ -22,16 +22,22 @@ if errorlevel 1 exit 1
     address-model=%ARCH% ^
     variant=release ^
     threading=multi ^
-    link=shared ^
+    link=static,shared ^
     -j%CPU_COUNT% ^
     -s ZLIB_INCLUDE="%LIBRARY_INC%" ^
     -s ZLIB_LIBPATH="%LIBRARY_LIB%"
 if errorlevel 1 exit 1
 
+for /F "tokens=1,2,3 delims=." %%a in ("%PKG_VERSION%") do (
+   set PKG_VERSION_MAJOR=%%a
+   set PKG_VERSION_MINOR=%%b
+   set PKG_VERSION_PATCH=%%c
+)
+
 :: Install fix-up for a non version-specific boost include
-move %LIBRARY_INC%\boost-1_59\boost %LIBRARY_INC%
+move %LIBRARY_INC%\boost-%PKG_VERSION_MAJOR%_%PKG_VERSION_MINOR%\boost %LIBRARY_INC%
 if errorlevel 1 exit 1
 
 :: Move dll's to LIBRARY_BIN
-move %LIBRARY_LIB%\*vc%LIB_VER%-mt-1_59.dll "%LIBRARY_BIN%"
+move %LIBRARY_LIB%\*vc%LIB_VER%-mt-%PKG_VERSION_MAJOR%_%PKG_VERSION_MINOR%.dll "%LIBRARY_BIN%"
 if errorlevel 1 exit 1

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -23,9 +23,18 @@ case `uname` in
         ;;
 esac
 
+# Use python-config or python3-config to determine Python headers path.
+MY_PYTHON_CONFIG="${PREFIX}/bin/python-config"
+if [[ ${PY3K} == 1 ]]; then
+    MY_PYTHON_CONFIG="${PREFIX}/bin/python3-config"
+fi
+MY_PYTHON_INCLUDES="$( "${MY_PYTHON_CONFIG}" --includes | sed s/-I//g )"
+
 ./bootstrap.sh \
     --prefix="${PREFIX}" \
     --with-icu="${PREFIX}" \
+    --with-python="${PYTHON}" \
+    --with-python-root="${PREFIX} : ${MY_PYTHON_INCLUDES}" \
     2>&1 | tee bootstrap.log
 
 ./b2 -q -j ${CPU_COUNT} \

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -12,8 +12,6 @@ set -x -e
 
 
 if [ "$(uname)" == "Darwin" ]; then
-    CXXFLAGS="-stdlib=libstdc++"
-    LINKFLAGS="-stdlib=libstdc++"
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \
@@ -28,8 +26,6 @@ if [ "$(uname)" == "Darwin" ]; then
         threading=multi \
         link=shared \
         toolset=clang \
-        cxxflags="${CXXFLAGS}" \
-        linkflags="${LINKFLAGS}" \
         -j ${CPU_COUNT} \
         install 2>&1 | tee b2.log
 fi

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -12,11 +12,8 @@ set -x -e
 
 
 if [ "$(uname)" == "Darwin" ]; then
-    MACOSX_VERSION_MIN=10.6
-    CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    CXXFLAGS="${CXXFLAGS} -stdlib=libstdc++"
-    LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    LINKFLAGS="${LINKFLAGS} -stdlib=libstdc++"
+    CXXFLAGS="-stdlib=libstdc++"
+    LINKFLAGS="-stdlib=libstdc++"
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -10,39 +10,25 @@
 
 set -x -e
 
+case `uname` in
+    Darwin)
+        b2_options=( toolset=clang )
+        ;;
+    Linux)
+        b2_options=( toolset=gcc )
+        ;;
+esac
 
-if [ "$(uname)" == "Darwin" ]; then
+./bootstrap.sh \
+    --prefix="${PREFIX}" \
+    --with-icu="${PREFIX}" \
+    2>&1 | tee bootstrap.log
 
-    ./bootstrap.sh \
-        --prefix="${PREFIX}" \
-        --with-icu="${PREFIX}" \
-        2>&1 | tee bootstrap.log
-
-    ./b2 -q \
-        variant=release \
-        address-model=${ARCH} \
-        architecture=x86 \
-        threading=multi \
-        link=shared \
-        toolset=clang \
-        -j ${CPU_COUNT} \
-        install 2>&1 | tee b2.log
-fi
-
-if [ "$(uname)" == "Linux" ]; then
-
-    ./bootstrap.sh \
-        --prefix="${PREFIX}" \
-        --with-icu="${PREFIX}" \
-        2>&1 | tee bootstrap.log
-
-    ./b2 -q \
-        variant=release \
-        address-model=${ARCH} \
-        architecture=x86 \
-        threading=multi \
-        link=shared \
-        toolset=gcc \
-        -j ${CPU_COUNT} \
-        install 2>&1 | tee b2.log
-fi
+./b2 -q -j ${CPU_COUNT} \
+    variant=release \
+    address-model=${ARCH} \
+    architecture=x86 \
+    threading=multi \
+    link=shared \
+    "${b2_options[@]}" \
+    install 2>&1 | tee b2.log

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -10,20 +10,16 @@
 
 set -x -e
 
-INCLUDE_PATH="${PREFIX}/include"
-LIBRARY_PATH="${PREFIX}/lib"
 
 if [ "$(uname)" == "Darwin" ]; then
     MACOSX_VERSION_MIN=10.6
     CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
     CXXFLAGS="${CXXFLAGS} -stdlib=libstdc++"
     LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    LINKFLAGS="${LINKFLAGS} -stdlib=libstdc++ -L${LIBRARY_PATH}"
+    LINKFLAGS="${LINKFLAGS} -stdlib=libstdc++"
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \
-        --with-python="${PYTHON}" \
-        --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
         --with-icu="${PREFIX}" \
         2>&1 | tee bootstrap.log
 
@@ -35,7 +31,6 @@ if [ "$(uname)" == "Darwin" ]; then
         threading=multi \
         link=shared \
         toolset=clang \
-        include="${INCLUDE_PATH}" \
         cxxflags="${CXXFLAGS}" \
         linkflags="${LINKFLAGS}" \
         -j ${CPU_COUNT} \
@@ -47,8 +42,6 @@ if [ "$(uname)" == "Linux" ]; then
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \
-        --with-python="${PYTHON}" \
-        --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
         --with-icu="${PREFIX}" \
         2>&1 | tee bootstrap.log
 
@@ -61,9 +54,6 @@ if [ "$(uname)" == "Linux" ]; then
         runtime-link=shared \
         link=shared \
         toolset=gcc \
-        python="${PY_VER}" \
-        include="${INCLUDE_PATH}" \
-        linkflags="-L${LIBRARY_PATH}" \
         --layout=system \
         -j ${CPU_COUNT} \
         install 2>&1 | tee b2.log

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -16,10 +16,7 @@ case `uname` in
         b2_options=( toolset=clang )
         ;;
     Linux)
-        b2_options=(
-            toolset=gcc
-            linkflags="'-Wl,-rpath,\$ORIGIN'"
-            )
+        b2_options=( toolset=gcc )
         ;;
 esac
 

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -25,7 +25,7 @@ if [ "$(uname)" == "Darwin" ]; then
         --with-python="${PYTHON}" \
         --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
         --with-icu="${PREFIX}" \
-        | tee bootstrap.log 2>&1
+        2>&1 | tee bootstrap.log
 
     ./b2 -q \
         variant=release \
@@ -38,8 +38,8 @@ if [ "$(uname)" == "Darwin" ]; then
         include="${INCLUDE_PATH}" \
         cxxflags="${CXXFLAGS}" \
         linkflags="${LINKFLAGS}" \
-        -j"$(sysctl -n hw.ncpu)" \
-        install | tee b2.log 2>&1
+        -j ${CPU_COUNT} \
+        install 2>&1 | tee b2.log
 fi
 
 if [ "$(uname)" == "Linux" ]; then
@@ -50,7 +50,7 @@ if [ "$(uname)" == "Linux" ]; then
         --with-python="${PYTHON}" \
         --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
         --with-icu="${PREFIX}" \
-        | tee bootstrap.log 2>&1
+        2>&1 | tee bootstrap.log
 
     ./b2 -q \
         variant=release \
@@ -65,6 +65,6 @@ if [ "$(uname)" == "Linux" ]; then
         include="${INCLUDE_PATH}" \
         linkflags="-L${LIBRARY_PATH}" \
         --layout=system \
-        -j"${CPU_COUNT}" \
-        install | tee b2.log 2>&1
+        -j ${CPU_COUNT} \
+        install 2>&1 | tee b2.log
 fi

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -15,7 +15,10 @@ case `uname` in
         b2_options=( toolset=clang )
         ;;
     Linux)
-        b2_options=( toolset=gcc )
+        b2_options=(
+            toolset=gcc
+            linkflags="'-Wl,-rpath,\$ORIGIN'"
+            )
         ;;
 esac
 

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -20,9 +20,8 @@ if [ "$(uname)" == "Darwin" ]; then
 
     ./b2 -q \
         variant=release \
-        address-model=64 \
+        address-model=${ARCH} \
         architecture=x86 \
-        debug-symbols=off \
         threading=multi \
         link=shared \
         toolset=clang \
@@ -31,7 +30,6 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 if [ "$(uname)" == "Linux" ]; then
-    echo "using gcc : : /usr/bin/g++44 ; " >> tools/build/src/user-config.jam
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \
@@ -40,14 +38,11 @@ if [ "$(uname)" == "Linux" ]; then
 
     ./b2 -q \
         variant=release \
-        address-model="${ARCH}" \
+        address-model=${ARCH} \
         architecture=x86 \
-        debug-symbols=off \
         threading=multi \
-        runtime-link=shared \
         link=shared \
         toolset=gcc \
-        --layout=system \
         -j ${CPU_COUNT} \
         install 2>&1 | tee b2.log
 fi

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -39,6 +39,6 @@ MY_PYTHON_INCLUDES="$( "${MY_PYTHON_CONFIG}" --includes | sed s/-I//g )"
     address-model=${ARCH} \
     architecture=x86 \
     threading=multi \
-    link=shared \
+    link=static,shared \
     "${b2_options[@]}" \
     install 2>&1 | tee b2.log

--- a/boost/build.sh
+++ b/boost/build.sh
@@ -9,6 +9,7 @@
 # http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
 
 set -x -e
+set -o pipefail
 
 case `uname` in
     Darwin)

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 6aa9a5c6a4ca1016edd0ed1178e3cb87
 
 build:
+  binary_relocation: False      [linux]
   features:
     - vc9               [win and py27]
     - vc10              [win and py34]

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: boost
-  version: 1.59.0
+  version: 1.61.0
 
 source:
-  fn:  boost_1_59_0.tar.bz2
-  url: http://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.tar.bz2
-  md5: 6aa9a5c6a4ca1016edd0ed1178e3cb87
+  fn:  boost_1_61_0.tar.bz2
+  url: http://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2
+  md5: 6095876341956f65f9d35939ccea1a9f
 
 build:
   features:
@@ -16,7 +16,7 @@ build:
 requirements:
   build:
     - python
-    - icu               [unix]
+    - icu 54.*          [unix]
     - bzip2             [unix]
     - zlib
 
@@ -24,7 +24,7 @@ requirements:
     # python dependency is here due to libboost-python library that depends on
     # python version
     - python
-    - icu               [unix]
+    - icu 54.*          [unix]
     - zlib
 
 about:

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -30,4 +30,3 @@ requirements:
 about:
   home: http://www.boost.org/
   license: Boost-1.0
-

--- a/boost/meta.yaml
+++ b/boost/meta.yaml
@@ -8,7 +8,6 @@ source:
   md5: 6aa9a5c6a4ca1016edd0ed1178e3cb87
 
 build:
-  binary_relocation: False      [linux]
   features:
     - vc9               [win and py27]
     - vc10              [win and py34]


### PR DESCRIPTION
Remove duplicate code and options set to boost build-system defaults.
Use MACOSX_DEPLOYMENT_TARGET from conda build-system environment instead of explicit compiler option.  Avoid using patchelf on Linux and the resulting larger and more fragile binaries.
