### PR TITLE
expat: new recipe (git dependency)

### DIFF
--- a/expat/build.sh
+++ b/expat/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+
+make
+make install

--- a/expat/meta.yaml
+++ b/expat/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: expat
+  version: 2.1.0
+
+source:
+  fn: expat-2.1.0.tar.gz
+  url: http://sourceforge.net/projects/expat/files/expat/2.1.0/expat-2.1.0.tar.gz
+  md5: dd7dab7a5fea97d2a6a43f511449b7cd
+
+requirements:
+  build:
+    - gcc
+
+about:
+  home: http://expat.sourceforge.net
+  license: MIT
+  summary: |
+    Expat is an XML parser library written in C. It is a stream-oriented parser
+    in which an application registers handlers for things the parser might find
+    in the XML document (like start tags).

--- a/expat/meta.yaml
+++ b/expat/meta.yaml
@@ -7,10 +7,6 @@ source:
   url: http://sourceforge.net/projects/expat/files/expat/2.1.0/expat-2.1.0.tar.gz
   md5: dd7dab7a5fea97d2a6a43f511449b7cd
 
-requirements:
-  build:
-    - gcc
-
 about:
   home: http://expat.sourceforge.net
   license: MIT


### PR DESCRIPTION
Expat is an XML parser library written in C. It is a stream-oriented parser in which an application registers handlers for things the parser might find in the XML document (like start tags).

You can test this package by installing it from `salford_systems` channel:

```
$ conda install -c salford_systems expat
```

Package on Anaconda.org: https://anaconda.org/salford_systems/expat