### PR TITLE
git: great refactoring - 8MB package instead of 93MB (!)

### DIFF
--- a/git/build.sh
+++ b/git/build.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-make configure
-./configure --prefix=$PREFIX
-make all
-make install
+export C_INCLUDE_PATH="$PREFIX/include"
 
-cd $PREFIX
-rm -rf lib lib64
-rm -rf share/man
-strip bin/* || echo
-strip libexec/git-core/* || echo
+# NO_TCLTK disables git-gui
+# NO_PERL disables all perl-based utils:
+#   git-instaweb, gitweb, git-cvsserver, git-svn
+#   /ref http://www.spinics.net/lists/git/msg99803.html
+# NO_GETTEXT disables internationalization (localized message translations)
+# NO_INSTALL_HARDLINKS uses symlinks which makes the package 85MB slimmer (8MB instead of 93MB!)
+make \
+    --jobs="$CPU_COUNT" \
+    prefix="$PREFIX" \
+    NO_TCLTK=1 \
+    NO_PERL=1 \
+    NO_GETTEXT=1 \
+    NO_INSTALL_HARDLINKS=1 \
+    all strip install

--- a/git/meta.yaml
+++ b/git/meta.yaml
@@ -13,7 +13,6 @@ build:
 
 requirements:
   build:
-    - gcc
     - expat
     - curl
     - openssl

--- a/git/meta.yaml
+++ b/git/meta.yaml
@@ -1,16 +1,26 @@
 package:
   name: git
-  version: 2.4.6
+  version: 2.6.3
 
 source:
-  git_url: git@github.com:git/git.git
-  git_tag: v2.4.6
+  fn: v2.6.3.tar.gz
+  url: https://github.com/git/git/archive/v2.6.3.tar.gz
+  md5: 65f659fb55ba49f17de03d1d9a859a83
+
+build:
+  # git hardcodes paths to external utilities (e.g. curl)
+  detect_binary_files_with_prefix: true
 
 requirements:
   build:
+    - gcc
+    - expat
+    - curl
     - openssl
     - zlib
   run:
+    - expat
+    - curl
     - openssl
     - zlib
 


### PR DESCRIPTION
The most significant shrinkage was achived by the `NO_INSTALL_HARDLINKS=1` - 8MB package instead of 93MB is a significant improvement.

I have also disabled perl utils and git-gui as them (from my point of view) are rarely used:

* `NO_TCLTK` disables git-gui
* `NO_PERL` disables all perl-based utils: git-instaweb, gitweb, git-cvsserver, git-svn (http://www.spinics.net/lists/git/msg99803.html)
* `NO_GETTEXT` disables internationalization (localized message translations) - avoids `gettext` build and run dependencies

You can test this package by installing it from `salford_systems` channel:

```
$ conda install -c salford_systems git
```

Package on Anaconda.org: https://anaconda.org/salford_systems/git

Please, also review #491 as it is a git dependecy.