### PR TITLE
isl: upgrade to 0.15

### DIFF
--- a/isl/meta.yaml
+++ b/isl/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: isl
-  version: 0.12.2
+  version: "0.15"
 
 source:
-  fn: isl-0.12.2.tar.bz2
-  url: ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.12.2.tar.bz2
-  sha1: ca98a91e35fb3ded10d080342065919764d6f928
+  fn: isl-0.15.tar.bz2
+  url: ftp://gcc.gnu.org/pub/gcc/infrastructure/isl-0.15.tar.bz2
+  md5: 8428efbbc6f6e2810ce5c1ba73ecf98c
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
GCC 5.x requires ISL 0.14+, but there is only ISL 0.12.2 in the official anaconda repo.