### PR TITLE
gcc-4.8: require isl >=0.10,<=0.14

### DIFF
--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 3
+  number: 4
 
 requirements:
   build:

--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -17,14 +17,14 @@ requirements:
     - gmp >=4.3.2
     - mpfr >=2.4.2
     - mpc >=0.8.1
-    - isl
+    - isl >=0.10,<=0.14
     - cloog 0.18.0
     # Do not make gcc a build dependency (you will need to add it to the PATH manually)
   run:
-    - gmp >=4.2
-    - mpfr >=2.4.0
-    - mpc >=0.8.0
-    - isl
+    - gmp >=4.3.2
+    - mpfr >=2.4.2
+    - mpc >=0.8.1
+    - isl >=0.10,<=0.14
     - cloog 0.18.0
 
 test:


### PR DESCRIPTION
Only 0.10, 0.11, 0.12, 0.14 versions are checked by ./configure:

```
checking for version 0.10 of ISL... no
checking for version 0.11 of ISL... no
checking for version 0.12 of ISL... no
checking for version 0.14 of ISL... no
configure: error: Unable to find a usable ISL.  See config.log for details.
```

/cc @stuarteberg @msarahan 