### PR TITLE
Update rpy2 to version 2.7.4.

### DIFF
--- a/rpy2/meta.yaml
+++ b/rpy2/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: rpy2
-  version: "2.7.0"
+  version: "2.7.4"
 
 source:
-  fn: rpy2-2.7.0.tar.gz
-  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.7.0.tar.gz
-  md5: afd9ea81a03640b60240b7d53518e652
+  fn: rpy2-2.7.4.tar.gz
+  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.7.4.tar.gz
+  md5: 62e6037388078a3bcf47642771e043ef
 #  patches:
    # List any patch files here
    # - fix.patch


### PR DESCRIPTION
This PR updates rpy2 to the newest release. A quick merge is critical, because rpy2 2.7.0 that is currently in conda stopped working with Python 3.5.1 because of [this bug](https://bitbucket.org/rpy2/rpy2/issues/312/python-35).

A quick merge would be much appreciated. Thanks!