### PR TITLE
add rtools 3.3 recipe

### DIFF
--- a/r-packages/r-rtools/bld.bat
+++ b/r-packages/r-rtools/bld.bat
@@ -1,0 +1,21 @@
+FOR %%F IN (%SRC_DIR%\*.exe) DO (
+    set FILENAME=%%F
+    goto found_file
+)
+:found_file
+
+%FILENAME% /SILENT /DIR="%TEMP%\rtools"
+if errorlevel 1 exit 1
+
+robocopy %TEMP%\rtools\bin %LIBRARY_BIN% /E *
+robocopy %TEMP%\rtools\mingw_%ARCH% %LIBRARY_PREFIX% /E *
+robocopy %TEMP%\rtools\mingw_libs\include\ %LIBRARY_PREFIX%\include /E *
+
+if "%ARCH%" == "64" (
+    robocopy %TEMP%\rtools\mingw_libs\lib\x64 %LIBRARY_PREFIX%\lib /E *
+) else (
+    robocopy %TEMP%\rtools\mingw_libs\lib\i386 %LIBRARY_PREFIX%\lib /E *
+)
+
+RD /S /Q "%TEMP%\rtools"
+exit 0

--- a/r-packages/r-rtools/meta.yaml
+++ b/r-packages/r-rtools/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: r-rtools
+  version: "3.3"
+
+source:
+  fn: Rtools33.exe
+  url:
+    - https://cran.r-project.org/bin/windows/Rtools/Rtools33.exe
+
+test:
+  commands:
+    - gcc --version
+
+about:
+  home: https://cran.r-project.org/bin/windows/Rtools/
+  license: GPL-2 | GPL-3
+  summary: Build tools for R on Windows


### PR DESCRIPTION
This bundles GCC and other required build tools using the R-provided Rtools installer.  It copies the files into our Library/bin folder structure.

ping @groutr 
