### PR TITLE
tensorflow 0.6.0

### DIFF
--- a/tensorflow/build.sh
+++ b/tensorflow/build.sh
@@ -3,9 +3,9 @@
 # install using pip from the whl file provided by Google
 
 if [ `uname` == Darwin ]; then
-    pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.5.0-py2-none-any.whl
+    pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.6.0-py2-none-any.whl
 fi
 
 if [[ (`uname` == Linux) ]]; then
-    pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.5.0-cp27-none-linux_x86_64.whl
+    pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
 fi

--- a/tensorflow/meta.yaml
+++ b/tensorflow/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: tensorflow
-  version: "0.5.0"
+  version: "0.6.0"
 
 build:
-  number: 2
+  number: 0
   entry_points:
     - tensorflow_model_cifar10_eval = tensorflow.models.image.cifar10.cifar10_eval:main
     - tensorflow_model_cifar10_multi_gpu_train = tensorflow.models.image.cifar10.cifar10_multi_gpu_train:main
@@ -15,11 +15,11 @@ requirements:
   build:
     - python
     - pip
-    - numpy >=1.9.2
+    - numpy >=1.8.2
     - six >=1.10.0
   run:
     - python
-    - numpy >=1.9.2
+    - numpy >=1.8.2
     - six >=1.10.0
 
 test:


### PR DESCRIPTION
Update the ``tensorflow`` recipe to 0.6.0 (released on 12/9/2015).

Also revise the ``numpy`` requirements to match those in the ``pypi`` description file (which may be a work in progress): https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/pip_package/setup.py