### PR TITLE
Update rpy2 to version 2.7.6 and fix failed builds by adding include dir to CFLAGS.

### DIFF
--- a/rpy2/build.sh
+++ b/rpy2/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+CFLAGS="-I$PREFIX/include" $PYTHON setup.py install
 
 # Add more build steps here, if they are necessary.
 

--- a/rpy2/meta.yaml
+++ b/rpy2/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: rpy2
-  version: "2.7.4"
+  version: "2.7.6"
 
 source:
-  fn: rpy2-2.7.4.tar.gz
-  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.7.4.tar.gz
-  md5: 62e6037388078a3bcf47642771e043ef
+  fn: rpy2-2.7.6.tar.gz
+  url: https://pypi.python.org/packages/source/r/rpy2/rpy2-2.7.6.tar.gz
+  md5: e2fdcbc5bbd3803256c39568c423dcd9
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -23,6 +23,7 @@ requirements:
     - argparse # [py26]
     - singledispatch # [not (py34 or py35)]
     - six
+    - readline
 
   run:
     - python
@@ -30,6 +31,7 @@ requirements:
     - argparse # [py26]
     - singledispatch # [not (py34 or py35)]
     - six
+    - readline
 
 test:
   # Python imports


### PR DESCRIPTION
The current version of rpy2 in the conda-recipes repository does not build. Here, I added readline as a dependency and fixed the CFLAGS such that the compiler finds it and rpy2 builds properly. I recommend to merge and rebuild quickly, because rpy2 is currently unusable with Python 3.5.1 in conda.