### PR TITLE
Add CPPFLAGS to SWIG recipe to increase portability

### DIFF
--- a/swig/build.sh
+++ b/swig/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export CPPFLAGS=-I$PREFIX/include
+
 ./configure --prefix=$PREFIX
 make -j${CPU_COUNT}
 #make check


### PR DESCRIPTION
See https://github.com/ContinuumIO/anaconda-issues/issues/395#issuecomment-168848818
for original suggestion.