### PR TITLE
Posix_ipc for Linux and Mac

### DIFF
--- a/posix_ipc/build.sh
+++ b/posix_ipc/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/posix_ipc/meta.yaml
+++ b/posix_ipc/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: posix_ipc
+  version: "1.0.0"
+
+source:
+  fn: posix_ipc-1.0.0.tar.gz
+  url: https://pypi.python.org/packages/source/p/posix_ipc/posix_ipc-1.0.0.tar.gz
+  md5: 85607a392087715ac3a3c7ded2492d06
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - posix_ipc
+
+about:
+  home: http://semanchuk.com/philip/posix_ipc/
+  license: BSD License
+  summary: 'POSIX IPC primitives (semaphores, shared memory and message queues) for Python'
+


### PR DESCRIPTION
An attempt was made to get this working in Windows, but the only way to get real Posix shared memory support seems to be by installing Cygwin.