### PR TITLE
Add recipe for pylearn2

### DIFF
--- a/pylearn2/build.sh
+++ b/pylearn2/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/pylearn2/meta.yaml
+++ b/pylearn2/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: pylearn2
+  version: 0.1
+
+source:
+  git_url: https://github.com/lisa-lab/pylearn2.git
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+    - theano
+
+  run:
+    - python
+    - numpy
+    - theano
+    - pyyaml
+
+about:
+  home: http://deeplearning.net/software/pylearn2/
+  license: BSD License
+

--- a/pylearn2/meta.yaml
+++ b/pylearn2/meta.yaml
@@ -4,6 +4,7 @@ package:
 
 source:
   git_url: https://github.com/lisa-lab/pylearn2.git
+  git_tag: stable-201601
 
 requirements:
   build:


### PR DESCRIPTION
Conda recipe for [lisa-lab/pylearn2](https://github.com/lisa-lab/pylearn2) at tag `stable-201601`. Known to work for linux64 and linux32.