### PR TITLE
memory_profiler: Bump to v0.41.

### DIFF
--- a/python/memory_profiler/meta.yaml
+++ b/python/memory_profiler/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: memory_profiler
-  version: "0.40"
+  version: "0.41"
 
 source:
-  fn: memory_profiler-0.40.tar.gz
-  url: https://pypi.python.org/packages/source/m/memory_profiler/memory_profiler-0.40.tar.gz
-  md5: 593d3adff124193e4205a36db9c5e82d
+  fn: memory_profiler-0.41.tar.gz
+  url: https://pypi.python.org/packages/source/m/memory_profiler/memory_profiler-0.41.tar.gz
+  md5: 8615aecbcc5cf1a761c819b9f4976cad
 
 requirements:
   build:


### PR DESCRIPTION
Turns out there is an import fix for Python 2 and functions that create strings or print. ( http://stackoverflow.com/questions/34638026/python-mprun-throws-typeerror )