### PR TITLE
Freeimage: fix win32 build.  Cleanup.

### DIFF
--- a/freeimage/bld.bat
+++ b/freeimage/bld.bat
@@ -1,5 +1,4 @@
-
-if defined ProgramFiles(x86) (
+if "%ARCH%" == "64" (
   set ARCH=x64
 ) else (
   set ARCH=Win32

--- a/freeimage/meta.yaml
+++ b/freeimage/meta.yaml
@@ -1,36 +1,34 @@
 package:
-    name: freeimage
-    version: 3.17.0
-    # note: also update version in run_test.py
+  name: freeimage
+  version: 3.17.0
 
 source:
-    fn: FreeImage3170.zip
-    url: http://optimate.dl.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip
-    md5: 459e15f0ec75d6efa3c7bd63277ead86
-    
-    patches:
-        - Makefile.osx.patch  # [osx]
-        - vs2010_omp.patch    # [win and py3k]
-        - vs_snprintf.patch   # [win and py>=3.5]
+  fn: FreeImage3170.zip
+  url: http://optimate.dl.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip
+  md5: 459e15f0ec75d6efa3c7bd63277ead86
+  patches:
+    - Makefile.osx.patch  # [osx]
+    - vs2010_omp.patch    # [win and py3k]
+    - vs_snprintf.patch   # [win and py>=3.5]
 
 build:
-    number: 1
-    features:
-        - vc9                [win and py27]
-        - vc10               [win and py34]
-        - vc14               [win and py35]
+  number:       1
+  features:
+    - vc9                [win and py27]
+    - vc10               [win and py34]
+    - vc14               [win and py35]
 
 requirements:
-    build:
-        # Python here forces tracking of vc features on win.
-        - python             [win]
+  build:
+    # Python here forces tracking of vc features on win.
+    - python             [win]
 
 test:
-    requires:
-        - python
-    commands:
-        - python run_test.py
+  requires:
+    - python
 
 about:
-    home: http://freeimage.sourceforge.net/
-    license: GPLv2 and FreeImage Public License
+  home: http://freeimage.sourceforge.net/
+  license: GPLv2 and FreeImage Public License
+  license_family: GPL2
+  summary: supports popular graphics image formats like PNG, BMP, JPEG, TIFF

--- a/freeimage/run_test.py
+++ b/freeimage/run_test.py
@@ -29,9 +29,7 @@ assert os.path.isfile(lib_fname2), "Could not find file: %s" % lib_fname2
 
 # Load library and get found version
 for fname in (lib_fname1, lib_fname2):
-    print('Testing', fname)
     lib = loader(fname)
     lib.FreeImage_GetVersion.restype = ctypes.c_char_p
     found_version = lib.FreeImage_GetVersion().decode('utf-8')
     assert lib_version == found_version
-    print('Test ok, FreeImage version:', found_version)


### PR DESCRIPTION
@almarklein please look these over.  These are the changes made in the Anaconda repository.

The only major change here is changing how 64-bit architecture is detected.  The way you had it is only for build-time architecture (what arch is the build machine), not what machine is the target environment.  Thus, my issue building was that I was getting 64-bit DLLs no matter what.
