### PR TITLE
py2app and Spyder alias app

### DIFF
--- a/altgraph/bld.bat
+++ b/altgraph/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/altgraph/build.sh
+++ b/altgraph/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/altgraph/meta.yaml
+++ b/altgraph/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: altgraph
+  version: "0.12"
+
+source:
+  fn: altgraph-0.12.tar.gz
+  url: https://pypi.python.org/packages/source/a/altgraph/altgraph-0.12.tar.gz
+  md5: 916dca277fb2b747d5b1ec05b54a0825
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - altgraph = altgraph:main
+    #
+    # Would create an entry point called altgraph that calls altgraph.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - altgraph
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://packages.python.org/altgraph
+  license: MIT License
+  summary: 'Python graph (network) package'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/macholib/MachOGraph.patch
+++ b/macholib/MachOGraph.patch
@@ -1,0 +1,11 @@
+--- macholib/MachOGraph.py	2015-05-17 16:56:31.000000000 -0400
++++ macholib/MachOGraph.py	2015-05-17 16:56:12.000000000 -0400
+@@ -46,7 +46,7 @@
+                 try:
+                     fn = dyld_find(filename, env=self.env,
+                         executable_path=self.executable_path,
+-                        loader=loader.filename)
++                        loader_path=loader.filename)
+                     self.trans_table[(loader.filename, filename)] = fn
+                 except ValueError:
+                     return None

--- a/macholib/bld.bat
+++ b/macholib/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/macholib/build.sh
+++ b/macholib/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/macholib/meta.yaml
+++ b/macholib/meta.yaml
@@ -1,0 +1,68 @@
+package:
+  name: macholib
+  version: "1.7"
+
+source:
+  fn: macholib-1.7.tar.gz
+  url: https://pypi.python.org/packages/source/m/macholib/macholib-1.7.tar.gz
+  md5: cf03a55323d5b7ca59be530ba0b01032
+
+  patches:
+    # This patch fixes a simple bad variable name.
+    # See py2app#137: https://bitbucket.org/ronaldoussoren/py2app/issue/137/py2app-problems-using-enthought-python
+    # See also: https://bitbucket.org/ronaldoussoren/macholib/pull-request/10/machographlocate-when-calling-dyld_find/diff#comment-None
+    - MachOGraph.patch
+
+build:
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - macholib = macholib:main
+    #
+    # Would create an entry point called macholib that calls macholib.main()
+
+    - macho_find = macholib.macho_find:main
+    - macho_standalone = macholib.macho_standalone:main
+    - macho_dump = macholib.macho_dump:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - altgraph >=0.12
+
+  run:
+    - python
+    - altgraph >=0.12
+
+test:
+  # Python imports
+  imports:
+    - macholib
+
+  commands:
+    - python -mmacholib dump ${PREFIX}/lib/libpython2.7.dylib
+    - macho_find ${PREFIX}/lib/libpython2.7.dylib
+    - macho_dump ${PREFIX}/lib/libpython2.7.dylib
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://bitbucket.org/ronaldoussoren/macholib
+  license: MIT License
+  summary: 'Mach-O header analysis and editing'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/modulegraph/bld.bat
+++ b/modulegraph/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/modulegraph/build.sh
+++ b/modulegraph/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/modulegraph/meta.yaml
+++ b/modulegraph/meta.yaml
@@ -1,0 +1,63 @@
+package:
+  name: modulegraph
+  version: "0.12.1"
+
+source:
+  fn: modulegraph-0.12.1.tar.gz
+  url: https://pypi.python.org/packages/source/m/modulegraph/modulegraph-0.12.1.tar.gz
+  md5: 27abd74de3ec0e22ef129c1faa628bd5
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - modulegraph = modulegraph:main
+    #
+    # Would create an entry point called modulegraph that calls modulegraph.main()
+
+    - modulegraph = modulegraph.__main__:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - altgraph >=0.12
+
+  run:
+    - python
+    - altgraph >=0.12
+
+test:
+  # Python imports
+  imports:
+    - modulegraph
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+    - modulegraph -m sys
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://bitbucket.org/ronaldoussoren/modulegraph
+  license: MIT License
+  summary: 'Python module dependency analysis tool'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/py2app/bld.bat
+++ b/py2app/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/py2app/build.sh
+++ b/py2app/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# The post-build logic chokes on these binary files, as described here:
+# https://github.com/conda/conda-build/issues/411
+
+# Since we don't needs these files on x86_64, let's just delete them.
+rm ${PREFIX}/lib/python2.7/site-packages/py2app-0.9-py2.7.egg/py2app/apptemplate/prebuilt/*-fat
+rm ${PREFIX}/lib/python2.7/site-packages/py2app-0.9-py2.7.egg/py2app/bundletemplate/prebuilt/*-fat

--- a/py2app/meta.yaml
+++ b/py2app/meta.yaml
@@ -1,0 +1,75 @@
+package:
+  name: py2app
+  version: "0.9"
+
+source:
+  fn: py2app-0.9.tar.gz
+  url: https://pypi.python.org/packages/source/p/py2app/py2app-0.9.tar.gz
+  md5: eb31f5fefcf80aeaf4d02ec68d5978b4
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - py2app = py2app:main
+    #
+    # Would create an entry point called py2app that calls py2app.main()
+
+    - py2applet = py2app.script_py2applet:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - altgraph >=0.12
+    - modulegraph >=0.12
+    - macholib >=1.5
+
+  run:
+    - python
+    - setuptools
+    - altgraph >=0.12
+    - modulegraph >=0.12
+    - macholib >=1.5
+
+test:
+  # Python imports
+  imports:
+    - py2app
+    - py2app.apptemplate
+    - py2app.bootstrap
+    - py2app.bundletemplate
+    - py2app.converters
+    - py2app.recipes
+    - py2app.recipes.PIL
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - py2applet --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://bitbucket.org/ronaldoussoren/py2app
+  license: MIT License
+  summary: 'Create standalone Mac OS X applications with Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/spyder-alias-app/build.sh
+++ b/spyder-alias-app/build.sh
@@ -1,0 +1,31 @@
+# Create spyder app in 'alias' mode, so it uses the anaconda environment.
+ ${PYTHON} create_app.py py2app --alias
+
+MAC_APP_NAME=$(${PYTHON} -c "\
+from __future__ import print_function; \
+import os; \
+from spyderlib.config.base import MAC_APP_NAME; \
+print(os.path.splitext(MAC_APP_NAME)[0])")
+
+mv dist/${MAC_APP_NAME}.app ${PREFIX}/bin/
+
+# Script to open spyder.app from the terminal
+LAUNCH_SCRIPT=${PREFIX}/bin/spyder-app
+cat > ${LAUNCH_SCRIPT} << EOF
+#!/bin/bash
+
+# If spyder is already running, call the executable directly,
+# which knows how to pass the user's arguments to the 
+# already-running instance, and will then exit.
+# (If spyder.app is already open, then it doesn't recognize 
+# arguments passed via the 'open' command. But this method works.)
+if pgrep '^'${MAC_APP_NAME}'$' > /dev/null; then
+    ${PREFIX}/bin/${MAC_APP_NAME}.app/Contents/MacOS/${MAC_APP_NAME} "\$@"
+else
+    # spyder isn't running yet.
+    # Use 'open' so it launches as if the user double-clicked it.
+    open ${PREFIX}/bin/${MAC_APP_NAME}.app --args "\$@"
+fi
+EOF
+
+chmod +x ${LAUNCH_SCRIPT}

--- a/spyder-alias-app/meta.yaml
+++ b/spyder-alias-app/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: spyder-alias-app
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('v', '') }}
+
+source:
+  #git_url: https://github.com/spyder-ide/spyder
+  #git_tag: HEAD
+  git_url: https://github.com/stuarteberg/spyder
+  git_tag: osx-alias-mode-app
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', '0') }}
+  script_env:
+    - USER
+
+requirements:
+  build:
+    - spyder
+    - py2app
+
+  run:
+    - spyder
+  
+about:
+  home: https://github.com/spyder-ide/spyder
+  license: MIT
+  summary: Scientific PYthon Development EnviRonment
+  


### PR DESCRIPTION
**DO NOT MERGE YET**

This PR shows how to generate an "alias mode" `.app` bundle on OSX for the `Spyder` application.  It will only work after spyder-ide/spyder#2954 is merged.

Also, this PR includes recipes for the `py2app` module (including a critical patch), since it's needed for generating `.app` bundles.
