### PR TITLE
add .binstar.yml necessary for CI testing

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -19,24 +19,25 @@ before_script:
 - export PYTHONPATH=$PYTHONPATH:./conda_tmp/conda-build:./conda_tmp/conda
 - echo "PYTHONPATH below should include ./conda_tmp"
 - echo $PYTHONPATH
-
+- conda install -c psteinberg protoci
 engine:
 - python
+- r
 script:
- - conda install -c psteinberg protoci
  - protoci-difference-build .
 install_channels:
 - defaults
 - python
+- r
 package: conda-recipes
 platform:
  - linux-64
+ - osx-32
  - osx-64
  - win-64
- - osx-32
-
+# anaconda.org username or org name:
 user: conda-team
+# suppress print of messages ending in \r (interactive ones)
 quiet: True
-
 #timeout after N seconds without IO
 iotimeout: 200

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,42 @@
+
+# Notes:
+# This .binstar.yml file controls CI testing of this repo
+# Adaptations for other uses may change the package name
+# or user.
+
+after_failure:
+- echo "After failure message!"
+after_script:
+- echo "ProtoCI build was a:$BINSTAR_BUILD_RESULT" | tee artifact1.txt
+after_success:
+- echo "ProtoCI BUILD SUCCESS"
+before_script:
+- echo "Prepare to clone conda and conda-build for metadata reading..."
+- mkdir conda_tmp
+# avoid conflict with conda or conda-build dirs if already there
+- git clone https://github.com/conda/conda-build conda_tmp/conda-build
+- git clone https://github.com/conda/conda conda_tmp/conda
+- export PYTHONPATH=$PYTHONPATH:./conda_tmp/conda-build:./conda_tmp/conda
+- echo "PYTHONPATH below should include ./conda_tmp"
+- echo $PYTHONPATH
+
+engine:
+- python
+script:
+ - conda install -c psteinberg protoci
+ - protoci-difference-build .
+install_channels:
+- defaults
+- python
+package: conda-recipes
+platform:
+ - linux-64
+ - osx-64
+ - win-64
+ - osx-32
+
+user: conda-team
+quiet: True
+
+#timeout after N seconds without IO
+iotimeout: 200


### PR DESCRIPTION
This `.binstar.yml` file needs to be added to the conda-recipes dir for CI testing to work.  

I have tested this in the psteinberg_CI_testing branch in this forked repository.

The `.binstar.yml` file controls the testing variables of:
 * anaconda.org user or org name, in this case `conda-team`,
 * iotimeout, how long to wait for a non-responsive build (seconds) before killing it,
 * package name for anaconda.org `conda-recipes`,
 * prebuild steps for installing the latest `protoci` so that the `protoci-difference-build` from [the files in the psteinberg label on anaconda.org](https://anaconda.org/psteinberg/ProtoCI/files) can be used,
 * running `protoci-difference-build`