### PR TITLE
Fix compatibility issues for gcc package

### DIFF
--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -58,7 +58,7 @@ make install-strip
 rm "$PREFIX"/lib64
 
 #Fix libtool paths
-find -name "$PREFIX"/*.la -print0 | xargs -0  sed -i 's%lib/../lib64%lib%g'
+find "$PREFIX"  -name '*.la' -print0 | xargs -0  sed -i 's%lib/../lib64%lib%g'
 
 # Link cc to gcc
 (cd "$PREFIX"/bin && ln -s gcc cc)

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -35,7 +35,7 @@ else
     # For reference during post-link.sh, record some
     # details about the OS this binary was produced with.
     mkdir -p "${PREFIX}/share"
-	# lsb_release can complain about LSB mosules in stderr, so we
+	# lsb_release can complain about LSB modules in stderr, so we
 	# ignore that.
     lsb_release -a 1> "${PREFIX}/share/conda-gcc-build-machine-os-details"
     ./configure \

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -35,7 +35,9 @@ else
     # For reference during post-link.sh, record some
     # details about the OS this binary was produced with.
     mkdir -p "${PREFIX}/share"
-    cat /etc/*-release > "${PREFIX}/share/conda-gcc-build-machine-os-details"
+	# lsb_release can complain about LSB mosules in stderr, so we
+	# ignore that.
+    lsb_release -a 1> "${PREFIX}/share/conda-gcc-build-machine-os-details"
     ./configure \
         --prefix="$GCC_PREFIX" \
         --with-gxx-include-dir="$GCC_PREFIX/include/c++" \

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -57,5 +57,8 @@ make -j"$CPU_COUNT"
 make install-strip
 rm "$PREFIX"/lib64
 
+#Fix libtool paths
+find -name "$PREFIX"/*.la -print0 | xargs -0  sed -i 's%lib/../lib64%lib%g'
+
 # Link cc to gcc
 (cd "$PREFIX"/bin && ln -s gcc cc)

--- a/gcc-4.8/build.sh
+++ b/gcc-4.8/build.sh
@@ -58,7 +58,8 @@ make install-strip
 rm "$PREFIX"/lib64
 
 #Fix libtool paths
-find "$PREFIX"  -name '*.la' -print0 | xargs -0  sed -i 's%lib/../lib64%lib%g'
+find "$PREFIX" -name '*.la' -print0 | xargs -0  sed -i.backup 's%lib/../lib64%lib%g'
+find "$PREFIX" -name '*la.backup' -print0 | xargs -0  rm -f
 
 # Link cc to gcc
 (cd "$PREFIX"/bin && ln -s gcc cc)

--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true # [not linux32]
-  number: 4
+  number: 5
 
 requirements:
   build:

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -171,3 +171,4 @@ if [ $SUCCESS -ne 0 ]; then
 fi
 
 cd .. && rm -r "$workdir"
+ln -s ${PREFIX}/lib ${PREFIX}/lib64

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -171,4 +171,3 @@ if [ $SUCCESS -ne 0 ]; then
 fi
 
 cd .. && rm -r "$workdir"
-ln -s ${PREFIX}/lib ${PREFIX}/lib64

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -7,7 +7,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 build_os_md5=( $(md5sum "${PREFIX}/share/conda-gcc-build-machine-os-details") )
-target_os_md5=( $(cat /etc/*-release | md5sum) )
+target_os_md5=( $(lsb_release -a | md5sum) )
 
 # No need to make any portability fixes if
 # we're deploying to the same OS we built with.


### PR DESCRIPTION
A lib64 folder need to be present on the system fot libtool not to
complain (so fixes  #563) and the way the system info is requested is not
universal enough.