### PR TITLE
Update imageio recipe for v1.5

### DIFF
--- a/python/imageio/meta.yaml
+++ b/python/imageio/meta.yaml
@@ -1,39 +1,30 @@
 package:
   name: imageio
-  version: 1.2
+  version: 1.5
 
 source:
-  fn: imageio-1.2-linux32.zip  [linux32]
-  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.2-linux32.zip  [linux32]
-  
-  fn: imageio-1.2-linux64.zip  [linux64]
-  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.2-linux64.zip  [linux64]
-  
-  fn: imageio-1.2-osx64.zip  [osx]
-  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.2-osx64.zip  [osx]
-  
-  fn: imageio-1.2-win32.zip  [win32]
-  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.2-win32.zip  [win32]
-  
-  fn: imageio-1.2-win64.zip  [win64]
-  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.2-win64.zip  [win64]
+  fn: imageio-1.5.zip
+  url: https://pypi.python.org/packages/source/i/imageio/imageio-1.5.zip
+  md5: 8fc2d37227e950a43bb500b55f360021
 
+build:
+  number: 1
 
 requirements:
   build:
     - python
 
   run:
-    - numpy
     - python
-  
+    - numpy
+    - freeimage
 
 test:
-  
   requires:
-    - numpy
+    - python
+    #- numpy  we dont run the test suite during build
     #- pytest
-  
+    #- freeimage
   imports:
     - imageio
 


### PR DESCRIPTION
Now that freeimage is available in the main channel (proposed in #335, implemented in #362), the recipe for imageio becomes straightforward.

I verified on Windows, OS X and Linux that imageio picks up the freeimage lib provided by the conda package.

Note that imageio does not depend on a specific version of numpy; is there a way to provide that info in the recipe, to avoid having to build the package against multiple numpy versions?

cc @ccordoba12 @blink1073 @msarahan
