### PR TITLE
[WIP] VTK 7 recipe supporting both Python 2 & 3

### DIFF
--- a/vtk/bld.bat
+++ b/vtk/bld.bat
@@ -3,7 +3,9 @@
 mkdir build
 cd build
 
-set PYLIB=python27.lib
+REM Remove dot from PY_VER for use in library name
+set MY_PY_VER=%PY_VER:.=%
+set PYLIB=python%MY_PY_VER%.lib
 
 cmake .. -G "NMake Makefiles" ^
     -Wno-dev ^
@@ -22,7 +24,8 @@ cmake .. -G "NMake Makefiles" ^
     -DPYTHON_INCLUDE_PATH=%PREFIX%\\include ^
     -DPYTHON_LIBRARY=%PREFIX%\\libs\\%PYLIB% ^
     -DVTK_INSTALL_PYTHON_MODULE_DIR=%PREFIX%\\Lib\\site-packages ^
-    -DModule_vtkRenderingMatplotlib=ON
+    -DModule_vtkRenderingMatplotlib=ON ^
+    -DVTK_PYTHON_VERSION=%PY_VER:~0,1%
 
 cmake --build . --target INSTALL --config Release
 if errorlevel 1 exit 1

--- a/vtk/build.sh
+++ b/vtk/build.sh
@@ -5,12 +5,8 @@ cd build
 
 if [ `uname` == Linux ]; then
     # Note: VTK 7 requires gcc >= 4.2
-    CC=gcc  # gcc44
-    CXX=g++ # g++44
-
-    # MY_PY_VER=${PY_VER}
-    # if [ "$PY3K" == "1" ]; then
-    #     MY_PY_VER="${MY_PY_VER}m"
+    CC=gcc
+    CXX=g++
 
     # use globs to take into account all possible suffixes: m, u, d
     PY_LIB=`ls "${PREFIX}/lib/libpython${PY_VER}"*.so | head -n 1`

--- a/vtk/build.sh
+++ b/vtk/build.sh
@@ -5,8 +5,8 @@ cd build
 
 if [ `uname` == Linux ]; then
     # Note: VTK 7 requires gcc >= 4.2
-    CC=gcc
-    CXX=g++
+    CC=gcc44
+    CXX=g++44
 
     # use globs to take into account all possible suffixes: m, u, d
     PY_LIB=`ls "${PREFIX}/lib/libpython${PY_VER}"*.so | head -n 1`
@@ -45,7 +45,7 @@ if [ `uname` == Darwin ]; then
         -DCMAKE_C_COMPILER=$CC \
         -DCMAKE_CXX_COMPILER=$CXX \
         -DVTK_REQUIRED_OBJCXX_FLAGS='' \
-        -DVTK_USE_CARBON=OFF \
+        -DVTK_USE_TK=OFF \
         -DVTK_USE_COCOA=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \

--- a/vtk/build.sh
+++ b/vtk/build.sh
@@ -4,9 +4,17 @@ mkdir build
 cd build
 
 if [ `uname` == Linux ]; then
-    CC=gcc44
-    CXX=g++44
-    PY_LIB="libpython${PY_VER}.so"
+    # Note: VTK 7 requires gcc >= 4.2
+    CC=gcc  # gcc44
+    CXX=g++ # g++44
+
+    # MY_PY_VER=${PY_VER}
+    # if [ "$PY3K" == "1" ]; then
+    #     MY_PY_VER="${MY_PY_VER}m"
+
+    # use globs to take into account all possible suffixes: m, u, d
+    PY_LIB=`ls "${PREFIX}/lib/libpython${PY_VER}"*.so | head -n 1`
+    PY_INC=`ls -d "${PREFIX}/include/python${PY_VER}"* | head -n 1`
 
     cmake .. \
         -DCMAKE_C_COMPILER=$CC \
@@ -21,17 +29,21 @@ if [ `uname` == Linux ]; then
         -DBUILD_SHARED_LIBS=ON \
         -DVTK_WRAP_PYTHON=ON \
         -DPYTHON_EXECUTABLE=${PYTHON} \
-        -DPYTHON_INCLUDE_PATH=${PREFIX}/include/python${PY_VER} \
-        -DPYTHON_LIBRARY=${PREFIX}/lib/${PY_LIB} \
+        -DPYTHON_INCLUDE_PATH=${PY_INC} \
+        -DPYTHON_LIBRARY=${PY_LIB} \
         -DVTK_INSTALL_PYTHON_MODULE_DIR=${SP_DIR} \
         -DModule_vtkRenderingMatplotlib=ON \
-        -DVTK_USE_X=ON
+        -DVTK_USE_X=ON \
+        -DVTK_PYTHON_VERSION=${PY_VER:0:1}
 fi
 
 if [ `uname` == Darwin ]; then
     CC=cc
     CXX=c++
-    PY_LIB="libpython${PY_VER}.dylib"
+
+    # use globs to take into account various possble suffixes: m, u, d
+    PY_LIB=`ls ${PREFIX}/lib/libpython${PY_VER}*.dylib | head -n 1`
+    PY_INC=`ls -d ${PREFIX}/include/python${PY_VER}* | head -n 1`
     SDK_PATH="/Developer/SDKs/MacOSX10.6.sdk"
 
     cmake .. \
@@ -52,11 +64,12 @@ if [ `uname` == Darwin ]; then
         -DBUILD_SHARED_LIBS=ON \
         -DVTK_WRAP_PYTHON=ON \
         -DPYTHON_EXECUTABLE=${PYTHON} \
-        -DPYTHON_INCLUDE_PATH=${PREFIX}/include/python${PY_VER} \
-        -DPYTHON_LIBRARY=${PREFIX}/lib/${PY_LIB} \
+        -DPYTHON_INCLUDE_PATH=${PY_INC} \
+        -DPYTHON_LIBRARY=${PY_LIB} \
         -DVTK_INSTALL_PYTHON_MODULE_DIR=${SP_DIR} \
         -DModule_vtkRenderingMatplotlib=ON \
-        -DVTK_USE_X=OFF
+        -DVTK_USE_X=OFF \
+        -DVTK_PYTHON_VERSION=${PY_VER:0:1}
 fi
 
 make -j${CPU_COUNT}

--- a/vtk/build.sh
+++ b/vtk/build.sh
@@ -44,15 +44,12 @@ if [ `uname` == Darwin ]; then
     # use globs to take into account various possble suffixes: m, u, d
     PY_LIB=`ls ${PREFIX}/lib/libpython${PY_VER}*.dylib | head -n 1`
     PY_INC=`ls -d ${PREFIX}/include/python${PY_VER}* | head -n 1`
-    SDK_PATH="/Developer/SDKs/MacOSX10.6.sdk"
 
     cmake .. \
         -DCMAKE_C_COMPILER=$CC \
         -DCMAKE_CXX_COMPILER=$CXX \
         -DVTK_REQUIRED_OBJCXX_FLAGS='' \
         -DVTK_USE_CARBON=OFF \
-        -DVTK_USE_TK=OFF \
-        -DIOKit:FILEPATH=${SDK_PATH}/System/Library/Frameworks/IOKit.framework \
         -DVTK_USE_COCOA=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \
@@ -70,6 +67,7 @@ if [ `uname` == Darwin ]; then
         -DModule_vtkRenderingMatplotlib=ON \
         -DVTK_USE_X=OFF \
         -DVTK_PYTHON_VERSION=${PY_VER:0:1}
+
 fi
 
 make -j${CPU_COUNT}

--- a/vtk/meta.yaml
+++ b/vtk/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: vtk
-  version: 6.3.0
+  version: 7.0.0
 
 source:
-  url: http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz
-  fn:  vtk-6.3.0.tar.gz
+  url: http://www.vtk.org/files/release/7.0/VTK-7.0.0.tar.gz
+  fn: vtk-v7.0.0.tar.gz
   patches:
     - dlls.patch                              [win]
     - apple.patch                             [osx]

--- a/vtk/run_test.py
+++ b/vtk/run_test.py
@@ -2,22 +2,22 @@
 
 # This simple example shows how to do basic rendering and pipeline
 # creation.
- 
+
 import vtk
 # The colors module defines various useful colors.
 from vtk.util.colors import tomato
- 
+
 # This creates a polygonal cylinder model with eight circumferential
 # facets.
 cylinder = vtk.vtkCylinderSource()
 cylinder.SetResolution(8)
- 
+
 # The mapper is responsible for pushing the geometry into the graphics
 # library. It may also do color mapping, if scalars or other
 # attributes are defined.
 cylinderMapper = vtk.vtkPolyDataMapper()
 cylinderMapper.SetInputConnection(cylinder.GetOutputPort())
- 
+
 # The actor is a grouping mechanism: besides the geometry (mapper), it
 # also has a property, transformation matrix, and/or texture map.
 # Here we set its color and rotate it -22.5 degrees.
@@ -26,7 +26,7 @@ cylinderActor.SetMapper(cylinderMapper)
 cylinderActor.GetProperty().SetColor(tomato)
 cylinderActor.RotateX(30.0)
 cylinderActor.RotateY(-45.0)
- 
+
 # Create the graphics structure. The renderer renders into the render
 # window. The render window interactor captures mouse events and will
 # perform appropriate camera or actor manipulation depending on the
@@ -36,21 +36,21 @@ renWin = vtk.vtkRenderWindow()
 renWin.AddRenderer(ren)
 iren = vtk.vtkRenderWindowInteractor()
 iren.SetRenderWindow(renWin)
- 
+
 # Add the actors to the renderer, set the background and size
 ren.AddActor(cylinderActor)
 ren.SetBackground(0.1, 0.2, 0.4)
 renWin.SetSize(200, 200)
- 
+
 # This allows the interactor to initalize itself. It has to be
 # called before an event loop.
 iren.Initialize()
- 
+
 # We'll zoom in a little by accessing the camera and invoking a "Zoom"
 # method on it.
 ren.ResetCamera()
 ren.GetActiveCamera().Zoom(1.5)
 renWin.Render()
- 
+
 # Start the event loop.
 iren.Start()


### PR DESCRIPTION
Hi,

I spent some time the other day getting VTK 7 to build with Python 3 wrappers and wanted to share my efforts.  I have marked this as work-in-progress because I am only sure that this recipe succeeds on 64-bit linux.  

On OSX Yosemite, the build completed successfully (at least once I installed XCode), but for some reason the import failed during running the tests and the package was not installed.  However, if I manually copy the VTK folder from the _build environment's site-packages folder into my primary environment's site-packages folder, it does seem to work properly. 

The windows case has not been tested at all, but I attempted to add the appropriate flag for Python 2 vs. 3
