### PR TITLE
Update qutip recipe

### DIFF
--- a/python/qutip/build.sh
+++ b/python/qutip/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install --with-f90mc
+$PYTHON setup.py install


### PR DESCRIPTION
- Remove -mcf90 flag so that fortran is not required.