### PR TITLE
Correct tensorflow 0.6 recipe

### DIFF
--- a/python/protobuf/meta.yaml
+++ b/python/protobuf/meta.yaml
@@ -1,13 +1,14 @@
 package:
   name: protobuf
-  version: !!str 2.5.0
+  version: !!str 3.0.0a3
 
 source:
-  fn: protobuf-2.5.0.tar.gz
-  url: https://pypi.python.org/packages/source/p/protobuf/protobuf-2.5.0.tar.gz
-  md5: 338813f3629d59e9579fed9035ecd457
+  fn: protobuf-3.0.0a3.tar.gz
+  url: https://pypi.python.org/packages/source/p/protobuf/protobuf-3.0.0a3.tar.gz
+  md5: 6674fa7452ebf066b767075db96a7ee0
 
 build:
+  number: 1
   preserve_egg_dir: True
 
 requirements:

--- a/python/tensorflow/build.sh
+++ b/python/tensorflow/build.sh
@@ -3,9 +3,17 @@
 # install using pip from the whl file provided by Google
 
 if [ `uname` == Darwin ]; then
-    pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.6.0-py2-none-any.whl
+    if [ "$PY_VER" == "2.7" ]; then
+        pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.6.0-py2-none-any.whl
+    else
+        pip install https://storage.googleapis.com/tensorflow/mac/tensorflow-0.6.0-py3-none-any.whl
+    fi
 fi
 
-if [[ (`uname` == Linux) ]]; then
-    pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
+if [ `uname` == Linux ]; then
+    if [ "$PY_VER" == "2.7" ]; then
+        pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp27-none-linux_x86_64.whl
+    else
+        pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.6.0-cp34-none-linux_x86_64.whl
+    fi
 fi

--- a/python/tensorflow/meta.yaml
+++ b/python/tensorflow/meta.yaml
@@ -3,13 +3,9 @@ package:
   version: "0.6.0"
 
 build:
-  number: 0
+  number: 1
   entry_points:
-    - tensorflow_model_cifar10_eval = tensorflow.models.image.cifar10.cifar10_eval:main
-    - tensorflow_model_cifar10_multi_gpu_train = tensorflow.models.image.cifar10.cifar10_multi_gpu_train:main
-    - tensorflow_model_cifar10_train = tensorflow.models.image.cifar10.cifar10_train:main
     - tensorboard = tensorflow.tensorboard.tensorboard:main
-    - tensorflow_model_mnist_convolutional = tensorflow.models.image.mnist.convolutional:main
 
 requirements:
   build:
@@ -17,10 +13,13 @@ requirements:
     - pip
     - numpy >=1.8.2
     - six >=1.10.0
+    - wheel >=0.26
+    - protobuf ==3.0.0a3
   run:
     - python
     - numpy >=1.8.2
     - six >=1.10.0
+    - protobuf ==3.0.0a3
 
 test:
   imports:


### PR DESCRIPTION
Tensorflow version 0.6 is available for Python 2.7 and 3.4, has a single entry point and requires protobuf 3.0.0a3.  This adds support for Python 3.4, corrects the recipe to require protobuf and removes the older non-existent entry point which were available in tensorflow 0.5.  

A recipe for protobuf 3.0.0a3 is also included as this particular version is requires for tensorflow 0.6.

Note that tensorflow is installed from whl packages provided by Google not from source.  There is a shared library in these wheels which may not be compatible with older version of Linux / OS X.