### PR TITLE
Require Cython for building NumPy and SciPy

### DIFF
--- a/python/numpy-openblas/meta.yaml
+++ b/python/numpy-openblas/meta.yaml
@@ -10,6 +10,7 @@ source:
 requirements:
   build:
     - python
+    - cython
     - openblas
 
   run:

--- a/python/scipy-openblas/meta.yaml
+++ b/python/scipy-openblas/meta.yaml
@@ -10,6 +10,7 @@ source:
 requirements:
   build:
     - python
+    - cython
     - openblas
     - numpy
 


### PR DESCRIPTION
The both have Cython source code that needs to be built and in some cases they may not have the C source code so the safest thing to do is include Cython for building.