### PR TITLE
nomkl: Add recipe for building metapackage.

### DIFF
--- a/nomkl/meta.yaml
+++ b/nomkl/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: nomkl
+  version: 1.0
+
+build:
+  track_features:
+    - nomkl


### PR DESCRIPTION
Simply adds the `nomkl` package. Seems like some people didn't have this one Windows. ( https://github.com/conda/conda/issues/2032#issuecomment-182322692 ) So, this gives them a way to build it. This, at least, seems to be how it works, but I could be missing something. Feedback welcome.