### PR TITLE
add configure step to git recipe

### DIFF
--- a/git/build.sh
+++ b/git/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export C_INCLUDE_PATH="$PREFIX/include"
-export LIBRARY_PATH="$PREFIX/lib"
+export C_INCLUDE_PATH="${PREFIX}/include"
+export LIBRARY_PATH="${PREFIX}/lib"
 
 # NO_TCLTK disables git-gui
 # NO_PERL disables all perl-based utils:
@@ -9,9 +9,10 @@ export LIBRARY_PATH="$PREFIX/lib"
 #   /ref http://www.spinics.net/lists/git/msg99803.html
 # NO_GETTEXT disables internationalization (localized message translations)
 # NO_INSTALL_HARDLINKS uses symlinks which makes the package 85MB slimmer (8MB instead of 93MB!)
+make configure
+./configure --prefix="${PREFIX}"
 make \
     --jobs="$CPU_COUNT" \
-    prefix="$PREFIX" \
     NO_TCLTK=1 \
     NO_PERL=1 \
     NO_GETTEXT=1 \


### PR DESCRIPTION
Without the configure step, the build process does not seem to respect the LIBRARY_PATH variable, and libraries end up not getting found.  I am guessing that the configure step records LIBRARY_PATH into its build steps.

This may have been masked in earlier builds by system libraries fulfilling needs (libssl is the one that kills the build for me).  This problem was highlighted when trying to build with a minimal docker image (https://hub.docker.com/r/msarahan/conda_builder_linux/)

Ping @frol @ccordoba12 - I know some people don't like the configure step because it introduces dependencies (m4? autotools?).  Is there a better way to do this that you know of?