### PR TITLE
cloud_sptheme: Update to 1.7.1

### DIFF
--- a/python/cloud_sptheme/meta.yaml
+++ b/python/cloud_sptheme/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cloud_sptheme
-  version: "1.7"
+  version: "1.7.1"
 
 source:
-  fn: cloud_sptheme-1.7.tar.gz
-  url: https://pypi.python.org/packages/source/c/cloud_sptheme/cloud_sptheme-1.7.tar.gz
-  md5: 8693d34d515da5462c03b2269dba20f3
+  fn: cloud_sptheme-1.7.1.tar.gz
+  url: https://pypi.python.org/packages/source/c/cloud_sptheme/cloud_sptheme-1.7.1.tar.gz
+  md5: 20a8725a72481a76432e3e1c3e8151a5
 #  patches:
    # List any patch files here
    # - fix.patch


### PR DESCRIPTION
Fixes some bugs. In particular, one on Python 3 that caused a `ZeroDivisionError` amongst others.