### PR TITLE
python-coveralls: Requre coveralls 3.x and adjust selector.

### DIFF
--- a/python/python-coveralls/meta.yaml
+++ b/python/python-coveralls/meta.yaml
@@ -29,19 +29,19 @@ requirements:
   build:
     - python
     - setuptools
-    - argparse [py26]
+    - argparse    #[py26]
     - pyyaml
     - requests
-    - coverage
+    - coverage <4
     - six
     - sh
 
   run:
     - python
-    - argparse [py26]
+    - argparse    #[py26]
     - pyyaml
     - requests
-    - coverage
+    - coverage <4
     - six
     - sh
 


### PR DESCRIPTION
Appears that `python-coveralls` does not work nicely with `coverage` 4.x. So, pin it to the 3.x line.