### PR TITLE
Qscintilla2

### DIFF
--- a/qscintilla2-qt4/bld.bat
+++ b/qscintilla2-qt4/bld.bat
@@ -46,7 +46,7 @@ if errorlevel 1 exit 1
 cd %SRC_DIR%\Python
 :: Use configure.py to generate a MAKEFILE
 @echo Configuring with python
-%PYTHON% configure.py --pyqt=PyQtn
+%PYTHON% configure.py
 if errorlevel 1 exit 1
 :: Build and install
 @echo Compiling python modules

--- a/qscintilla2-qt4/build.sh
+++ b/qscintilla2-qt4/build.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 BIN=$PREFIX/bin
-QT_MAJOR_VER=`qmake -v | sed -n 's/.*Qt version \([0-9])*\).*/\1/p'`
-if [ -z "$QT_MAJOR_VER" ]; then
-	echo "Could not determine Qt version of string provided by qmake:"
-	echo `qmake -v`
-	echo "Aborting..."
-	exit 1
-else
-	echo "Building Qscintilla for Qt${QT_MAJOR_VER}"
-fi
 
 # Set build specs depending on current platform (Mac OS X or Linux)
 if [ `uname` == Darwin ]; then
@@ -20,7 +11,7 @@ fi
 # Go to Qscintilla source dir and then to its Qt4Qt5 folder.
 cd ${SRC_DIR}/Qt4Qt5
 # Build the makefile with qmake, specify llvm as the compiler
-# The normal g++ compiler on Mac causes an __Unwind_Resume error at linking phase
+# The normal g++ compiler causes an __Unwind_Resume error at linking phase
 ${BIN}/qmake qscintilla.pro -spec ${BUILD_SPEC}
 # Build Qscintilla
 make
@@ -32,7 +23,7 @@ make install
 # Go to python folder
 cd ${SRC_DIR}/Python
 # Configure compilation of Python Qsci module
-${PYTHON} configure.py --pyqt=PyQt${QT_MAJOR_VER} --qmake=${BIN}/qmake --sip=${BIN}/sip --qsci-incdir=${PREFIX}/include/qt --qsci-libdir=${PREFIX}/lib --spec=${BUILD_SPEC} --no-qsci-api 
+${PYTHON} configure.py --qmake=${BIN}/qmake --sip=${BIN}/sip --qsci-incdir=${PREFIX}/include --qsci-libdir=${PREFIX}/lib --spec=${BUILD_SPEC} --no-qsci-api 
 # make it
 make
 

--- a/qscintilla2-qt4/meta.yaml
+++ b/qscintilla2-qt4/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: qscintilla2
+  version: 2.9.1
+
+source:
+  fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [unix]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz  [unix]
+  md5:  38e6248cb970adf6d05aea7d94f1288e                                                                        [unix]
+  fn:   QScintilla-gpl-2.9.1.zip                                                                                [win]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip     [win]
+  md5:  d2a12047d90c33c227e82093b2c0e158                                                                        [win]
+
+requirements:
+  build:
+    - python     
+    - sip         >=4.16.4
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4 
+
+  run:
+    - python
+    - sip         >=4.16.4
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4
+
+build:
+  features:
+    - vc9           [win and py27]
+    - vc10          [win and py34]
+    - vc14          [win and py35]
+  script_env:
+    - LOCALAPPDATA  [win and py27]
+
+test:
+  imports:
+    - PyQt4.Qsci
+
+about:
+    home: https://www.riverbankcomputing.com/software/qscintilla/intro
+    summary: "Qscintilla2 editor for PyQt package"
+    license: GPLv3

--- a/qscintilla2/bld.bat
+++ b/qscintilla2/bld.bat
@@ -1,23 +1,63 @@
+@echo off
+:: MSVC library for Python 2.7 is not found automaticaly if it is 
+:: installed in the user's AppData folder. Add it to PATH
+setlocal EnableDelayedExpansion
+
+if "%PY_VER%"=="2.7" (
+	set VC9DIR=%LOCALAPPDATA%\Programs\Common\Microsoft\Visual C++ for Python\9.0
+	IF EXIST !VC9DIR! ( 
+		set PATH=!VC9DIR!;"%PATH%"
+		if %ARCH% == 32 call vcvarsall.bat x86
+		if %ARCH% == 64 call vcvarsall.bat amd64
+		:: vcvarsall does something strange with PATH, preventing xcopy to be found later. Fix this
+		set PATH=!PATH!;%SYSTEMROOT%\system32
+	)
+)
+if errorlevel 1 exit 1
+
 :: Set QMAKESPEC to the appropriate MSVC compiler
 set QMAKESPEC=%LIBRARY_PREFIX%\mkspecs\win32-msvc-default
 
+@echo ====================================================
+@echo Building Qscintilla2
+@echo ====================================================
 :: Go to the source folder and enter the Qt4Qt5 dir
 cd %SRC_DIR%\Qt4Qt5
 :: Use qmake to generate a make file
 %LIBRARY_BIN%\qmake qscintilla.pro
+if errorlevel 1 exit 1
+
+@echo Compiling
 :: Build and install
 nmake
+if errorlevel 1 exit 1
+@echo Installing (copying)
+@echo ====================================================
+@echo PATH = %PATH%
+@echo ====================================================
 nmake install
+if errorlevel 1 exit 1
 
+@echo ====================================================
+@echo Building Python bindings
+@echo ====================================================
 :: Python bindings
 :: Go into the Python folder
 cd %SRC_DIR%\Python
 :: Use configure.py to generate a MAKEFILE
+@echo Configuring with python
 %PYTHON% configure.py
+if errorlevel 1 exit 1
 :: Build and install
+@echo Compiling python modules
 nmake
+if errorlevel 1 exit 1
+@echo Installing python modules
 nmake install
+if errorlevel 1 exit 1
 :: The qscintilla2.dll ends up in Anaconda's lib dir, where Python
 :: can't find it for import. Copy it to the bin dir
 :: (as indicated at http://pyqt.sourceforge.net/Docs/QScintilla2/)
 copy %LIBRARY_LIB%\qscintilla2.dll %LIBRARY_BIN%
+if errorlevel 1 exit 1
+@echo finished

--- a/qscintilla2/bld.bat
+++ b/qscintilla2/bld.bat
@@ -1,0 +1,3 @@
+set QMAKESPEC=%LIBRARY_PREFIX%\mkspecs\win32-msvc-default
+
+%LIBRARY_BIN%\qmake qscintilla.pro

--- a/qscintilla2/bld.bat
+++ b/qscintilla2/bld.bat
@@ -15,8 +15,18 @@ if "%PY_VER%"=="2.7" (
 )
 if errorlevel 1 exit 1
 
+:: Determine Qt Major verion (4 or 5)
+for /f "tokens=4" %%i in ('%LIBRARY_BIN%\qmake -v ^| find "Qt version"') do (
+	set QT_MAJOR_VER=%%i
+	set QT_MAJOR_VER=!QT_MAJOR_VER:~0,1!
+)
+if [!QT_MAJOR_VER!] == [] Exit /B 1
+
+@echo Building for Qt!QT_MAJOR_VER!
+
 :: Set QMAKESPEC to the appropriate MSVC compiler
-set QMAKESPEC=%LIBRARY_PREFIX%\mkspecs\win32-msvc-default
+:: Not really necessary in windows
+:: set QMAKESPEC=%LIBRARY_PREFIX%\mkspecs\win32-msvc-default
 
 @echo ====================================================
 @echo Building Qscintilla2
@@ -46,7 +56,7 @@ if errorlevel 1 exit 1
 cd %SRC_DIR%\Python
 :: Use configure.py to generate a MAKEFILE
 @echo Configuring with python
-%PYTHON% configure.py --pyqt=PyQtn
+%PYTHON% configure.py --pyqt=PyQt!QT_MAJOR_VER!
 if errorlevel 1 exit 1
 :: Build and install
 @echo Compiling python modules

--- a/qscintilla2/bld.bat
+++ b/qscintilla2/bld.bat
@@ -1,3 +1,23 @@
+:: Set QMAKESPEC to the appropriate MSVC compiler
 set QMAKESPEC=%LIBRARY_PREFIX%\mkspecs\win32-msvc-default
 
+:: Go to the source folder and enter the Qt4Qt5 dir
+cd %SRC_DIR%\Qt4Qt5
+:: Use qmake to generate a make file
 %LIBRARY_BIN%\qmake qscintilla.pro
+:: Build and install
+nmake
+nmake install
+
+:: Python bindings
+:: Go into the Python folder
+cd %SRC_DIR%\Python
+:: Use configure.py to generate a MAKEFILE
+%PYTHON% configure.py
+:: Build and install
+nmake
+nmake install
+:: The qscintilla2.dll ends up in Anaconda's lib dir, where Python
+:: can't find it for import. Copy it to the bin dir
+:: (as indicated at http://pyqt.sourceforge.net/Docs/QScintilla2/)
+copy %LIBRARY_LIB%\qscintilla2.dll %LIBRARY_BIN%

--- a/qscintilla2/build.sh
+++ b/qscintilla2/build.sh
@@ -1,30 +1,36 @@
 #!/bin/bash
-
 BIN=$PREFIX/bin
 
+# Set build specs depending on current platform (Mac OS X or Linux)
 if [ `uname` == Darwin ]; then
-	## Build main dylib ##
-
-	# Go to Qscintilla source dir and then to its Qt4Qt5 folder.
-	cd ${SRC_DIR}/Qt4Qt5
-	# Build the makefile with qmake, specify llvm as the compiler
-	# The normal g++ compiler causes an __Unwind_Resume error at linking phase
-	${BIN}/qmake qscintilla.pro -spec macx-llvm
-	# Build Qscintilla
-	make
-	# and install it
-	make install
-
-	## Build Python module ##
-
-	# Go to python folder
-	cd ${SRC_DIR}/Python
-	# Configure compilation of Python Qsci module
-	${PYTHON} configure.py --qmake=${BIN}/qmake --sip=${BIN}/sip --qsci-incdir=${PREFIX}/include --qsci-libdir=${PREFIX}/lib --spec=macx-llvm --no-qsci-api 
-	# make it
-	make
-	# Change reference from libQsci.dylib to Qsci.so (otherwise anaconda linker crashes)
-	install_name_tool -id Qsci.so Qsci.so
-	# Install QSci.so to the site-packages/PyQt4 folder
-	make install
+	BUILD_SPEC=macx-llvm
+else
+	BUILD_SPEC=linux-g++
 fi
+
+# Go to Qscintilla source dir and then to its Qt4Qt5 folder.
+cd ${SRC_DIR}/Qt4Qt5
+# Build the makefile with qmake, specify llvm as the compiler
+# The normal g++ compiler causes an __Unwind_Resume error at linking phase
+${BIN}/qmake qscintilla.pro -spec ${BUILD_SPEC}
+# Build Qscintilla
+make
+# and install it
+make install
+
+## Build Python module ##
+
+# Go to python folder
+cd ${SRC_DIR}/Python
+# Configure compilation of Python Qsci module
+${PYTHON} configure.py --qmake=${BIN}/qmake --sip=${BIN}/sip --qsci-incdir=${PREFIX}/include --qsci-libdir=${PREFIX}/lib --spec=${BUILD_SPEC} --no-qsci-api 
+# make it
+make
+
+# On OSX: Change reference from libQsci.dylib to Qsci.so (otherwise anaconda linker crashes)
+if [ `uname` == Darwin ]; then
+	install_name_tool -id Qsci.so Qsci.so
+fi
+
+# Install QSci.so to the site-packages/PyQt4 folder
+make install

--- a/qscintilla2/build.sh
+++ b/qscintilla2/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+BIN=$PREFIX/bin
+
+if [ `uname` == Darwin ]; then
+	## Build main dylib ##
+
+	# Go to Qscintilla source dir and then to its Qt4Qt5 folder.
+	cd ${SRC_DIR}/Qt4Qt5
+	# Build the makefile with qmake, specify llvm as the compiler
+	# The normal g++ compiler causes an __Unwind_Resume error at linking phase
+	${BIN}/qmake qscintilla.pro -spec macx-llvm
+	# Build Qscintilla
+	make
+	# and install it
+	make install
+
+	## Build Python module ##
+
+	# Go to python folder
+	cd ${SRC_DIR}/Python
+	# Configure compilation of Python Qsci module
+	${PYTHON} configure.py --qmake=${BIN}/qmake --sip=${BIN}/sip --qsci-incdir=${PREFIX}/include --qsci-libdir=${PREFIX}/lib --spec=macx-llvm --no-qsci-api 
+	# make it
+	make
+	# Change reference from libQsci.dylib to Qsci.so (otherwise anaconda linker crashes)
+	install_name_tool -id Qsci.so Qsci.so
+	# Install QSci.so to the site-packages/PyQt4 folder
+	make install
+fi

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -10,24 +10,24 @@ source:
   url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip     [win]
   md5:  d2a12047d90c33c227e82093b2c0e158                                                                        [win]
 
+requirements:
+  build:
+    - python     
+    - sip         >=4.16.4
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4 
+
+  run:
+    - python
+    - sip         >=4.16.4
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4
+
 build:
   features:
     - vc9     [win and py27]
     - vc10    [win and py34]
     - vc14    [win and py35]
-
-requirements:
-  build:
-    - python      >=2.7*
-    - qt          >=4.8.7
-    - pyqt        >=4.11.4
-    - sip         >=4.16.4
-
-  run:
-    - python      >=2.7*
-    - qt          >=4.8.7
-    - pyqt        >=4.11.4
-    - sip         >=4.16.4
 
 test:
   imports:

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -30,7 +30,6 @@ build:
     - vc14          [win and py35]
   script_env:
     - LOCALAPPDATA  [win and py27]
-    - QT_API
 
 test:
   imports:

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: qscintilla2
+  version: 2.9.1
+
+source:
+  fn:   QScintilla-gpl-2.9.1.tar.gz                                   [unix]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz                        [unix]
+  md5:  38e6248cb970adf6d05aea7d94f1288e                              [unix]
+  fn:   QScintilla-gpl-2.9.1.tar.gz                                   [win]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip                           [win]
+  md5:  d2a12047d90c33c227e82093b2c0e158                              [win]
+
+requirements:
+  build:
+    - python      >=2.7*
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4
+    - sip         >=4.16.4
+
+  run:
+    - python      >=2.7*
+    - qt          >=4.8.7
+    - pyqt        >=4.11.4
+    - sip         >=4.16.4
+about:
+    home: https://www.riverbankcomputing.com/software/qscintilla/intro
+    license: GPLv3

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -18,13 +18,13 @@ build:
 
 requirements:
   build:
-    - python      >=2.7
+    - python      >=2.7*
     - qt          >=4.8.7
     - pyqt        >=4.11.4
     - sip         >=4.16.4
 
   run:
-    - python      >=2.7
+    - python      >=2.7*
     - qt          >=4.8.7
     - pyqt        >=4.11.4
     - sip         >=4.16.4

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -1,27 +1,27 @@
 package:
   name: qscintilla2
-  version: 2.9.1
+  version: 2.9.3
 
 source:
-  fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [unix]
-  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz  [unix]
-  md5:  38e6248cb970adf6d05aea7d94f1288e                                                                        [unix]
-  fn:   QScintilla-gpl-2.9.1.zip                                                                                [win]
-  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip     [win]
-  md5:  d2a12047d90c33c227e82093b2c0e158                                                                        [win]
+  fn:   QScintilla-gpl-2.9.3.tar.gz                                                                             [unix]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.tar.gz  [unix]
+  md5:  3b1cdbce9ef6c28cd868bcc58219f96e                                                                        [unix]
+  fn:   QScintilla-gpl-2.9.3.zip                                                                                [win]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.zip     [win]
+  md5:  2b0da639a8ec3d4a37c69a5539d22569                                                                        [win]
 
 requirements:
   build:
     - python     
-    - sip         >=4.16.4
-    - qt          >=4.8.7
-    - pyqt        >=4.11.4 
+    - sip         >=4.18
+    - qt          >=5.6
+    - pyqt        >=5.6 
 
   run:
     - python
-    - sip         >=4.16.4
-    - qt          >=4.8.7
-    - pyqt        >=4.11.4
+    - sip         >=4.18
+    - qt          >=5.6
+    - pyqt        >=5.6
 
 build:
   features:
@@ -30,10 +30,11 @@ build:
     - vc14          [win and py35]
   script_env:
     - LOCALAPPDATA  [win and py27]
+    - QT_API
 
 test:
   imports:
-    - PyQt4.Qsci
+    - PyQt5.Qsci
 
 about:
     home: https://www.riverbankcomputing.com/software/qscintilla/intro

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -25,9 +25,11 @@ requirements:
 
 build:
   features:
-    - vc9     [win and py27]
-    - vc10    [win and py34]
-    - vc14    [win and py35]
+    - vc9           [win and py27]
+    - vc10          [win and py34]
+    - vc14          [win and py35]
+  script_env:
+    - LOCALAPPDATA  [win and py27]
 
 test:
   imports:

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -3,25 +3,37 @@ package:
   version: 2.9.1
 
 source:
-  fn:   QScintilla-gpl-2.9.1.tar.gz                                   [unix]
-  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz                        [unix]
-  md5:  38e6248cb970adf6d05aea7d94f1288e                              [unix]
-  fn:   QScintilla-gpl-2.9.1.tar.gz                                   [win]
-  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip                           [win]
-  md5:  d2a12047d90c33c227e82093b2c0e158                              [win]
+  fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [unix]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz  [unix]
+  md5:  38e6248cb970adf6d05aea7d94f1288e                                                                        [unix]
+  fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [win]
+  url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip     [win]
+  md5:  d2a12047d90c33c227e82093b2c0e158                                                                        [win]
+
+build:
+  features:
+    - vc9     [win and py27]
+    - vc10    [win and py34]
+    - vc14    [win and py35]
 
 requirements:
   build:
-    - python      >=2.7*
+    - python      >=2.7
     - qt          >=4.8.7
     - pyqt        >=4.11.4
     - sip         >=4.16.4
 
   run:
-    - python      >=2.7*
+    - python      >=2.7
     - qt          >=4.8.7
     - pyqt        >=4.11.4
     - sip         >=4.16.4
+
+test:
+  imports:
+    - PyQt4.Qsci
+
 about:
     home: https://www.riverbankcomputing.com/software/qscintilla/intro
+    summary: "Qscintilla2 editor for PyQt package"
     license: GPLv3

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -6,7 +6,7 @@ source:
   fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [unix]
   url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.tar.gz  [unix]
   md5:  38e6248cb970adf6d05aea7d94f1288e                                                                        [unix]
-  fn:   QScintilla-gpl-2.9.1.tar.gz                                                                             [win]
+  fn:   QScintilla-gpl-2.9.1.zip                                                                                [win]
   url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.1/QScintilla-gpl-2.9.1.zip     [win]
   md5:  d2a12047d90c33c227e82093b2c0e158                                                                        [win]
 

--- a/qscintilla2/meta.yaml
+++ b/qscintilla2/meta.yaml
@@ -1,29 +1,22 @@
+
+{% set name = "qscintilla2" %}
+{% set version = "2.9.3" %}
+{% set md5 = "3b1cdbce9ef6c28cd868bcc58219f96e" %}
+
 package:
-  name: qscintilla2
-  version: 2.9.3
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  fn:   QScintilla-gpl-2.9.3.tar.gz                                                                             [unix]
+  fn:   QScintilla-gpl-2.9.3.tar.gz [unix]
   url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.tar.gz  [unix]
-  md5:  3b1cdbce9ef6c28cd868bcc58219f96e                                                                        [unix]
-  fn:   QScintilla-gpl-2.9.3.zip                                                                                [win]
+  md5:  {{ md5 }}                  [unix]
+  fn:   QScintilla-gpl-2.9.3.zip   [win]
   url:  http://downloads.sourceforge.net/project/pyqt/QScintilla2/QScintilla-2.9.3/QScintilla_gpl-2.9.3.zip     [win]
-  md5:  2b0da639a8ec3d4a37c69a5539d22569                                                                        [win]
-
-requirements:
-  build:
-    - python     
-    - sip         >=4.18
-    - qt          >=5.6
-    - pyqt        >=5.6 
-
-  run:
-    - python
-    - sip         >=4.18
-    - qt          >=5.6
-    - pyqt        >=5.6
+  md5:  2b0da639a8ec3d4a37c69a5539d22569  [win]
 
 build:
+  number: 0
   features:
     - vc9           [win and py27]
     - vc10          [win and py34]
@@ -31,11 +24,33 @@ build:
   script_env:
     - LOCALAPPDATA  [win and py27]
 
+requirements:
+  build:
+    - python     
+    - sip
+    - qt
+    - pyqt
+
+  run:
+    - python
+    - sip
+    - qt
+    - pyqt
+
 test:
   imports:
     - PyQt5.Qsci
 
 about:
-    home: https://www.riverbankcomputing.com/software/qscintilla/intro
-    summary: "Qscintilla2 editor for PyQt package"
-    license: GPLv3
+  home: https://www.riverbankcomputing.com/software/qscintilla/intro
+  license: GPL-3.0
+  summary: "Qscintilla2 editor for Qt"
+  description: |
+    QScintilla is a port to Qt of Neil Hodgson's Scintilla C++ editor control.
+    As well as features found in standard text editing components, QScintilla includes features especially useful when editing and debugging source code. These include support for syntax styling, error indicators, code completion and call tips. The selection margin can contain markers like those used in debuggers to indicate breakpoints and the current line. Styling choices are more open than with many editors, allowing the use of proportional fonts, bold and italics, multiple foreground and background colours and multiple fonts.
+  doc_url: http://pyqt.sourceforge.net/Docs/QScintilla2/annotated.html
+  dev_url: https://www.riverbankcomputing.com/software/qscintilla/download
+
+extra:
+  recipe-maintainers:
+    - dschreij


### PR DESCRIPTION
Working recipes for MacOS and Windows (32/64 bit) to build qscintilla2 against qt4/pyqt4.
Once (py)qt5 is released I will try build it against that too.