### PR TITLE
Removing Misuse of Build Versions

### DIFF
--- a/r-packages/r-magrittr/meta.yaml
+++ b/r-packages/r-magrittr/meta.yaml
@@ -9,6 +9,8 @@ source:
   url:
     - http://cran.r-project.org/src/contrib/magrittr_1.5.tar.gz
     - http://cran.r-project.org/src/contrib/Archive/magrittr/magrittr_1.5.tar.gz
+
+
   # You can add a hash for the file here, like md5 or sha1
   # md5: 49448ba4863157652311cc5ea4fea3ea
   # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
@@ -19,8 +21,7 @@ source:
 build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  number: 2 # [osx]
-  number: 1 # [not osx]
+  # number: 1
 
   # This is required to make R link correctly on Linux.
   rpaths:


### PR DESCRIPTION
This pull request removes the OS specific build versions which isn't what these values are meant for.