### PR TITLE
add pip install ruamel.yaml to binstar.yml

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -19,6 +19,7 @@ before_script:
 - export PYTHONPATH=$PYTHONPATH:./conda_tmp/conda-build:./conda_tmp/conda
 - echo "PYTHONPATH below should include ./conda_tmp"
 - echo $PYTHONPATH
+- pip install ruamel.yaml
 - conda install -c psteinberg protoci
 - conda config --add channels r
 engine:


### PR DESCRIPTION
Small change needed for the .binstar.yaml CI configuration - to install a package metadata yaml library ruamel.yaml.