### PR TITLE
Fix incomplete manual merge in gsl recipe.

### DIFF
--- a/gsl/build.sh
+++ b/gsl/build.sh
@@ -1,12 +1,12 @@
-<<<<<<< HEAD
 if [[ "$(uname)" == "Darwin" ]]; then
   # CC=clang otherwise:
-  # error: ambiguous instructions require an explicit suffix (could be 'filds', or 'fildl')
+  # error: ambiguous instructions require an explicit suffix
+  # (could be 'filds', or 'fildl')
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509
   export CC=clang
 fi
 
-./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX --with-pic
 
 make -j ${CPU_COUNT}
 make check


### PR DESCRIPTION
Remove conflict marker.  Restore the `--with-pic` option from
the main branch.  Reformat comments to fit within 78 characters.