### PR TITLE
Improve wxpython

### DIFF
--- a/python/wxpython/build.sh
+++ b/python/wxpython/build.sh
@@ -2,7 +2,7 @@
 
 mkdir -vp ${PREFIX}/bin;
 
-ARCH="$(uname 2>/dev/null)"
+MYARCH="$(uname 2>/dev/null)"
 
 export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC"
 export CXXFLAGS="${CFLAGS} -std=c++11"
@@ -58,12 +58,12 @@ LinuxInstallation() {
     return 0;
 }
 
-case ${ARCH} in
+case ${MYARCH} in
     'Linux')
         LinuxInstallation || exit 1;
         ;;
     *)
-        echo -e "Unsupported machine type: ${ARCH}";
+        echo -e "Unsupported machine type: ${MYARCH}";
         exit 1;
         ;;
 esac

--- a/python/wxpython/build.sh
+++ b/python/wxpython/build.sh
@@ -3,6 +3,7 @@
 mkdir -vp ${PREFIX}/bin;
 
 MYARCH="$(uname 2>/dev/null)"
+MYNCPU=$(( (CPU_COUNT > 8) ? 8 : CPU_COUNT ))
 
 MYCFLAGS=""
 if [[ ${ARCH} == 64 ]]; then
@@ -44,7 +45,7 @@ LinuxInstallation() {
         --with-regex=builtin \
         --with-zlib=builtin \
         --prefix="${PREFIX}" || return 1;
-    make || return 1;
+    make -j ${MYNCPU} || return 1;
     make install || return 1;
 
     pushd wxPython/;
@@ -70,7 +71,3 @@ case ${MYARCH} in
         exit 1;
         ;;
 esac
-
-#POST_LINK="${PREFIX}/bin/.wxpython-post-link.sh"
-#cp -v ${RECIPE_DIR}/post-link.sh ${POST_LINK};
-#chmod -v 0755 ${POST_LINK};

--- a/python/wxpython/build.sh
+++ b/python/wxpython/build.sh
@@ -53,12 +53,6 @@ LinuxInstallation() {
         --record installed_files.txt --prefix="${PREFIX}" || return 1;
     popd;
 
-    rm ${PREFIX}/bin/wx-config || return 1;
-
-    pushd ${PREFIX};
-    ln -vs ../lib/wx/config/inplace-gtk2-unicode-3.0 wx-config || return 1;
-    popd;
-
     return 0;
 }
 

--- a/python/wxpython/build.sh
+++ b/python/wxpython/build.sh
@@ -4,11 +4,14 @@ mkdir -vp ${PREFIX}/bin;
 
 MYARCH="$(uname 2>/dev/null)"
 
-export CFLAGS="-m64 -pipe -O2 -march=x86-64 -fPIC"
+MYCFLAGS=""
+if [[ ${ARCH} == 64 ]]; then
+    MYCFLAGS="-m64 -march=x86-64"
+fi
+
+export CFLAGS="${MYCFLAGS} -pipe -O2 -fPIC"
 export CXXFLAGS="${CFLAGS} -std=c++11"
 export CPPFLAGS="${CFLAGS} -std=c++11"
-#export CPPFLAGS="-I${PREFIX}/include"
-#export LDFLAGS="-L${PREFIX}/lib64"
 
 LinuxInstallation() {
     # Build dependencies:

--- a/python/wxpython/meta.yaml
+++ b/python/wxpython/meta.yaml
@@ -1,4 +1,3 @@
-
 package:
     name: wxpython
     version: 3.0.2.0
@@ -9,7 +8,7 @@ source:
     sha1: 5053f3fa04f4eb3a9d4bfd762d963deb7fa46866
 
 build:
-    number: 2
+    number: 3
 
 requirements:
     build:


### PR DESCRIPTION
- support build on 32-bit Linux systems.
- fix broken symbolic link to wx-config.
- use up to 8 CPU-s when building wxpython.
- do not overwrite the ARCH environment variable set from conda-build.
