### PR TITLE
Fix lapack for conda_builder_linux from ContinuumIO/docker-images

### DIFF
--- a/lapack/build.sh
+++ b/lapack/build.sh
@@ -1,8 +1,11 @@
 mkdir build
 cd build
 
+# CMAKE_INSTALL_LIBDIR="lib" suppresses CentOS default of lib64 (conda expects lib)
+
 cmake \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_INSTALL_LIBDIR="lib" \
   -DBUILD_TESTING=OFF \
   -DBUILD_SHARED_LIBS=ON \
   -DLAPACKE=ON \


### PR DESCRIPTION
See https://github.com/ContinuumIO/docker-images/issues/23
ping @msarahan 

Actually I would need to remove both `gcc` and `libgcc` from meta.yaml for this to work out of the
box with `conda_builder_linux`.

What is the policy for adding compiler requirements in conda-recipes? My take is that
they can be kept in the recipe but commented out.