### PR TITLE
nlopt: explicit python version dependency

### DIFF
--- a/python/nlopt/meta.yaml
+++ b/python/nlopt/meta.yaml
@@ -3,15 +3,16 @@ package:
   version: 2.4.2
 
 build:
-  number: 1
+  number: 2
 
 requirements: # [not win]
   build:      # [not win]
+    - python {{PY_VER}}* # [not win]
     - gcc     # [linux]
     - numpy   # [not win]
 
   run:
-    - python  # [not win]
+    - python {{PY_VER}}*  # [not win]
     - numpy   # [not win]
     - libgcc  # [not win]
 


### PR DESCRIPTION
apparently packages that depend on numpy should always list their python dependency explicitly:
https://github.com/conda/conda-build/issues/835

this fixes the build for another python version:
```conda build --python 3.4 python/nlopt```
