### PR TITLE
patch.py: Fix unified / multi-file patch handling

### DIFF
--- a/common-scripts/patch.py
+++ b/common-scripts/patch.py
@@ -382,6 +382,8 @@ class PatchSet(object):
 
         headscan = False
         # switch to filenames state
+        srcname = None
+        tgtname = None
         filenames = True
 
       line = fe.line
@@ -461,10 +463,16 @@ class PatchSet(object):
           # switch to hunkhead state
           hunkskip = False
           hunkhead = True
-        elif line.startswith(b"--- "):
-          # switch to filenames state
+        elif line.startswith(b"--- ") or line.startswith(b"diff"):
           hunkskip = False
-          filenames = True
+          if line.startswith(b"--- "):
+            # switch to filenames state
+            srcname = None
+            tgtname = None
+            filenames = True
+          else:
+            # switch to headscan state
+            headscan  = True
           if debugmode and len(self.items) > 0:
             debug("- %2d hunks for %s" % (len(p.hunks), p.source))
 


### PR DESCRIPTION
2 fixes for patch.py. The gnuwin32 patch.exe is crashing on some of my patches and it's holding me up so so I'm thinking to replace it with this in conda-build; before I can do that, this needs to be rock solid.