### PR TITLE
Make gdal activate script also work in other shells.

### DIFF
--- a/gdal/posix/activate.sh
+++ b/gdal/posix/activate.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 if [[ -z "$GDAL_DATA" ]]; then
-  DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-  export GDAL_DATA="${DIR}/../../../share/gdal"
+  export GDAL_DATA=$(gdal-config --datadir)
   export _CONDA_SET_GDAL_DATA=1
 fi


### PR DESCRIPTION
This works for me in both bash and zsh. Fix #677