### PR TITLE
graphviz: Major changes

### DIFF
--- a/graphviz/build.sh
+++ b/graphviz/build.sh
@@ -6,11 +6,26 @@ export CXXLAGS="${CFLAGS}"
 export CPPFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"
 
+./autogen.sh
+
 if [ `uname` == Darwin ]; then
-./configure --prefix=$PREFIX --with-quartz | tee configure.log 2>&1
+./configure --prefix=$PREFIX --with-quartz
 else
-./configure --prefix=$PREFIX | tee configure.log 2>&1
+./configure --prefix=$PREFIX
 fi
-make install | tee make.log 2>&1
+
+make -j${CPU_COUNT}
+
+if [[ $(uname) == Darwin ]]; then
+    # For some reason, libltdl.7.dylib can't be found without setting the rpath,
+    # and it even prevents 'make install' from working.
+    install_name_tool -add_rpath ${PREFIX}/lib cmd/dot/.libs/dot
+fi 
+
+make install
 
 # vim: set ai et nu:
+
+# Configure plugins
+# (Writes ${PREFIX}/lib/graphviz/config with available plugin information.)
+$PREFIX/bin/dot -c

--- a/graphviz/meta.yaml
+++ b/graphviz/meta.yaml
@@ -3,30 +3,45 @@ package:
   version: "2.38.0"
 
 source:
-  fn: graphviz-2.38.0.tar.gz
-  url: http://www.graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz
-  md5: 5b6a829b2ac94efcd5fa3c223ed6d3ae
+  git_url: https://github.com/ellson/graphviz
+  git_rev: f54ac2c9313ae80ccf76ef4ac6aa9be820a23126 # "2.38 stable release"
+
   patches:
      - gvconfig_libdir.patch
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:
-    - cairo
+    - autoconf
+    - automake
+    - pkg-config
+    - libtool
+    - expat
+    - tk
     - libpng
     - libtiff
     - freetype
     - jpeg
     - zlib
+    - cairo # [linux]
+
+    # No conda package for these yet.
+    # Bison and Flex must be available on the build system.
+    # - bison
+    # - flex
+
   run:
-    - cairo
+    - libtool
+    - expat
+    - tk
     - libpng
     - libtiff
     - freetype
     - jpeg
     - zlib
+    - cairo # [linux]
 
 test:
   commands:

--- a/graphviz/post-link.sh
+++ b/graphviz/post-link.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-
-$PREFIX/bin/dot -c


### PR DESCRIPTION
The current version of the `graphviz` package in the conda `defaults` channel seems to be broken.  For example, it expects the user to have `libtool`, `expat`, and `tk` installed to the system.  This PR fixes it.

Also, the graphviz website is (apparently) quite unreliable -- it was down earlier today, for example.  It seems be back up now, but the problem seems to [pop up with some frequency](https://github.com/ellson/graphviz/issues/77).  So now I've changed this recipe to clone from the official git repo instead of downloading a tarball.

- Build from scratch, from the official git repo
- Require libtool and expat (they seem to be necessary, the package is broken without them)
- Don't use cairo on OS X, since it's an optional dependency and it isn't available in the defaults channel (for OS X).
- Moved post-link code into build.sh

I tested these changes on Mac and Linux.  Packages available on my channel:

```
conda install -c stuarteberg graphviz
```

One caveat: As always, Graphviz cannot build without yacc (or bison) and lex (or flex), so you can't build this recipe without those tools installed to your system.  (They are not yet available as conda packages.)

cc: @jakirkham