### PR TITLE
gcc-4.8: add library paths reported by system linker

### DIFF
--- a/gcc-4.8/meta.yaml
+++ b/gcc-4.8/meta.yaml
@@ -13,7 +13,7 @@ source:
 # along with using ${GCC_PREFIX}/.. fixes the issues with our configuration.
 build:
   detect_binary_files_with_prefix: false
-  number: 6
+  number: 7
 
 requirements:
   build:

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -46,7 +46,7 @@ else
     c_runtime_obj_files_found=0
 
     # Try locating crtXXX.o in default library search paths
-    for library_path in $(ld --verbose | grep SEARCH_DIR | sed -r 's/SEARCH_DIR\("=?([^"]*)"\);/ \1/g'); do
+    for library_path in $(/usr/bin/ld --verbose | grep SEARCH_DIR | sed -r 's/SEARCH_DIR\("=?([^"]*)"\);/ \1/g'); do
         for obj_file in $C_RUNTIME_OBJ_FILES; do
             obj_file_full_path="$library_path/$obj_file"
             if [[ -e "$obj_file_full_path" ]]; then

--- a/gcc-4.8/post-link.sh
+++ b/gcc-4.8/post-link.sh
@@ -111,6 +111,13 @@ else
         # ... yada yada ... -isystem ${INCDIR}
         sed -i ':a;N;$!ba;s|\(*cpp:\n[^\n]*\)|\1 -isystem '${INCDIR}'|g' "${SPECS_FILE}"
     done
+
+    #
+    # Linux Portability Issue #2.5: linker also needs to find the rest of libc (i.e. libc.so in addition to crtXXX.o)
+    #
+    for library_path in $(/usr/bin/ld --verbose | grep SEARCH_DIR | sed -r 's/SEARCH_DIR\("=?([^"]*)"\);/ \1/g'); do
+         sed -i ':a;N;$!ba;s|\(*link_libgcc:\n[^\n]*\)|\1 -L'${library_path}'|g' "${SPECS_FILE}"
+    done
 fi
 
 ## TEST: Here we verify that gcc can build a simple "Hello world" program for both C and C++.


### PR DESCRIPTION
Right now only part of the system's libc is symlinked into the conda env - namely the startup files crtXXX.o.
In addition the path to the actual shared object libc.so also needs to be added to the spec file in case a custom
linker is used inside the conda env (e.g. because binutils is requested).

This fixes the following error I get when I conda build a package that requires both gcc-4.8 and binutils:
`/home/speter/miniconda2/envs/_build/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
Installation failed: gcc is not able to compile a simple 'Hello, World' program.`

 cc @stuarteberg
