### PR TITLE
New gcc recipes

### DIFF
--- a/cross-compilers/crosstool-ng/meta.yaml
+++ b/cross-compilers/crosstool-ng/meta.yaml
@@ -16,6 +16,11 @@ source:
   # for aarch64, used ct-ng master at above commit
   git_url: https://github.com/diorcety/crosstool-ng.git
   git_tag: {{ commit }}
+  patches:
+    - no-lto.patch
+
+build:
+  number: 1
 
 requirements:
   build:

--- a/cross-compilers/crosstool-ng/no-lto.patch
+++ b/cross-compilers/crosstool-ng/no-lto.patch
@@ -1,0 +1,41 @@
+From 237479a0617dfbc9de8e49b31ebe907f074ef7b4 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 15 Feb 2017 14:33:25 +0000
+Subject: [PATCH] uClibc/glibc: add -fno-lto when making dummy shared libs
+
+Otherwise the build machine's lto plugin gets loaded and
+that segfaults when processing your host machine's dummy
+shared lib
+
+Signed-off-by: Ray Donnelly <mingw.android@gmail.com>
+---
+ scripts/build/libc/glibc.sh  | 1 +
+ scripts/build/libc/uClibc.sh | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/build/libc/glibc.sh b/scripts/build/libc/glibc.sh
+index 348c35a..04416ea 100644
+--- a/scripts/build/libc/glibc.sh
++++ b/scripts/build/libc/glibc.sh
+@@ -431,6 +431,7 @@ do_libc_backend_once() {
+                                            -nostartfiles              \
+                                            -shared                    \
+                                            -x c /dev/null             \
++                                           -fno-lto                   \
+                                            -o "${startfiles_dir}/libc.so"
+         fi # threads == nptl
+     fi # libc_mode = startfiles
+diff --git a/scripts/build/libc/uClibc.sh b/scripts/build/libc/uClibc.sh
+index e87abaf..fe18ac4 100644
+--- a/scripts/build/libc/uClibc.sh
++++ b/scripts/build/libc/uClibc.sh
+@@ -197,7 +197,7 @@ do_libc_backend_once() {
+             # libm.so is needed for ppc, as libgcc is linked against libm.so
+             # No problem to create it for other archs.
+             CT_DoLog EXTRA "Building dummy shared libs"
+-            CT_DoExecLog ALL "${CT_TARGET}-${CT_CC}" -nostdlib -nostartfiles \
++            CT_DoExecLog ALL "${CT_TARGET}-${CT_CC}" -nostdlib -nostartfiles -fno-lto \
+                 -shared ${multi_flags} -x c /dev/null -o libdummy.so
+ 
+             CT_DoLog EXTRA "Installing start files"
+

--- a/cross-compilers/gcc-cross-aarch64/compiler_linux-64_linux-aarch64-activate.sh
+++ b/cross-compilers/gcc-cross-aarch64/compiler_linux-64_linux-aarch64-activate.sh
@@ -74,12 +74,12 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host aarch64-sarc-linux-gnueabi aarch64-sarc-linux-gnueabi- \
   addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,"-D_FORTIFY_SOURCE=2" \
-  CFLAGS,"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe" \
-  CXXFLAGS,"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe" \
-  LDFLAGS,"-Wl,-O1,--sort-common,--as-needed,-z,relro" \
-  DEBUG_CFLAGS,"-Og -g -fvar-tracking-assignments" \
-  DEBUG_CXXFLAGS,"-Og -g -fvar-tracking-assignments"
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc-cross-aarch64/compiler_linux-64_linux-aarch64-deactivate.sh
+++ b/cross-compilers/gcc-cross-aarch64/compiler_linux-64_linux-aarch64-deactivate.sh
@@ -74,13 +74,12 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host aarch64-sarc-linux-gnueabi aarch64-sarc-linux-gnueabi- \
   addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,"-D_FORTIFY_SOURCE=2" \
-  CFLAGS,"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe" \
-  CXXFLAGS,"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe" \
-  LDFLAGS,"-Wl,-O1,--sort-common,--as-needed,-z,relro" \
-  DEBUG_CFLAGS,"-Og -g -fvar-tracking-assignments" \
-  DEBUG_CXXFLAGS,"-Og -g -fvar-tracking-assignments"
-
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=armv6k -mtune=arm1136jf-s -mfloat-abi=soft -mabi=aapcs-linux -mtls-dialect=gnu -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 if [ $? -ne 0 ]; then
   echo "ERROR: Cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/activate-binutils.sh
+++ b/cross-compilers/gcc/activate-binutils.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++filt elfedit gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"
+#exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/activate-binutils.sh
+++ b/cross-compilers/gcc/activate-binutils.sh
@@ -73,13 +73,7 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++filt elfedit gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+  addr2line ar as c++filt elfedit gprof ld ldd nm objcopy objdump ranlib readelf size strings strip
 
 
 if [ $? -ne 0 ]; then
@@ -87,6 +81,6 @@ if [ $? -ne 0 ]; then
 #exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Activating '${HOST}-binutils' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/activate-binutils.sh
+++ b/cross-compilers/gcc/activate-binutils.sh
@@ -70,10 +70,11 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++filt elfedit gprof ld ldd nm objcopy objdump ranlib readelf size strings strip
+  activate host ${CHOST} ${CHOST}- \
+  addr2line ar as c++filt elfedit gprof ld nm objcopy objdump ranlib readelf size strings strip
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/activate-g++.sh
+++ b/cross-compilers/gcc/activate-g++.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"
+#exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/activate-g++.sh
+++ b/cross-compilers/gcc/activate-g++.sh
@@ -74,10 +74,9 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host ${CHOST} ${CHOST}- \
-  c++ cpp g++ \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fPIC -fvar-tracking-assignments"}
+  c++ g++ \
+  "CXXFLAGS,${CXXFLAGS:--march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11}" \
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:--Og -g -fPIC -fvar-tracking-assignments}"
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/activate-g++.sh
+++ b/cross-compilers/gcc/activate-g++.sh
@@ -70,13 +70,14 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  activate host ${CHOST} ${CHOST}- \
   c++ cpp g++ \
   CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fPIC -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/activate-g++.sh
+++ b/cross-compilers/gcc/activate-g++.sh
@@ -73,12 +73,9 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  c++ cpp g++ \
   CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
   CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
   DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
@@ -87,6 +84,6 @@ if [ $? -ne 0 ]; then
 #exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Activating '${HOST}-g++' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/activate-gcc.sh
+++ b/cross-compilers/gcc/activate-gcc.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"
+#exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/activate-gcc.sh
+++ b/cross-compilers/gcc/activate-gcc.sh
@@ -70,13 +70,14 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  activate host ${CHOST} ${CHOST}- \
   gcc gcc-ar gcc-nm gcc-ranlib \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
   LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"}
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fPIC -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/activate-gcc.sh
+++ b/cross-compilers/gcc/activate-gcc.sh
@@ -74,10 +74,11 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host ${CHOST} ${CHOST}- \
-  gcc gcc-ar gcc-nm gcc-ranlib \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fPIC -fvar-tracking-assignments"}
+  cpp gcc gcc-ar gcc-nm gcc-ranlib \
+  "CFLAGS,${CFLAGS:--march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong}" \
+  "CPPFLAGS,${CPPFLAGS:--D_FORTIFY_SOURCE=2}" \
+  "LDFLAGS,${LDFLAGS:--Wl,-O1,--sort-common,--as-needed,-z,relro}" \
+  "DEBUG_CFLAGS,${DEBUG_CFLAGS:--Og -g -fPIC -fvar-tracking-assignments}"
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/activate-gcc.sh
+++ b/cross-compilers/gcc/activate-gcc.sh
@@ -73,13 +73,10 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  gcc gcc-ar gcc-nm gcc-ranlib \
   CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
   LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then
@@ -87,6 +84,6 @@ if [ $? -ne 0 ]; then
 #exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Activating '${HOST}-gcc' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/activate-gfortran.sh
+++ b/cross-compilers/gcc/activate-gfortran.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"
+#exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/activate-gfortran.sh
+++ b/cross-compilers/gcc/activate-gfortran.sh
@@ -70,13 +70,14 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  activate host ${CHOST} ${CHOST}- \
   gfortran \
-  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
-  FORTRANFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
-  DEBUG_FFLAGS,${FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none"} \
+  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -fPIC -O3"} \
+  FORTRANFLAGS,${FORTRANFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -fPIC -O3"} \
+  DEBUG_FFLAGS,${DEBUG_FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fPIC -fimplicit-none"} \
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"

--- a/cross-compilers/gcc/activate-gfortran.sh
+++ b/cross-compilers/gcc/activate-gfortran.sh
@@ -75,9 +75,9 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host ${CHOST} ${CHOST}- \
   gfortran \
-  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -fPIC -O3"} \
-  FORTRANFLAGS,${FORTRANFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -fPIC -O3"} \
-  DEBUG_FFLAGS,${DEBUG_FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fPIC -fimplicit-none"} \
+  "FFLAGS,${FFLAGS:--march=nocona -Wall -Wextra -fopenmp -fPIC -O3}" \
+  "FORTRANFLAGS,${FORTRANFLAGS:--march=nocona -Wall -Wextra -fopenmp -fPIC -O3}" \
+  "DEBUG_FFLAGS,${DEBUG_FFLAGS:--Og -g -Wall -Wextra -fcheck=all -fbacktrace -fPIC -fimplicit-none}"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"

--- a/cross-compilers/gcc/activate-gfortran.sh
+++ b/cross-compilers/gcc/activate-gfortran.sh
@@ -73,20 +73,16 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
-
+  gfortran \
+  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
+  FORTRANFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
+  DEBUG_FFLAGS,${FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none"} \
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler activation failed, see above for details"
 #exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Activating '${HOST}' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Activating '${HOST}-gfortran' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/activate.sh
+++ b/cross-compilers/gcc/activate.sh
@@ -74,12 +74,12 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   activate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
   addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,"-D_FORTIFY_SOURCE=2" \
-  CFLAGS,"-march=westmere -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong" \
-  CXXFLAGS,"-march=westmere -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11" \
-  LDFLAGS,"-Wl,-O1,--sort-common,--as-needed,-z,relro" \
-  DEBUG_CFLAGS,"-Og -g -fvar-tracking-assignments" \
-  DEBUG_CXXFLAGS,"-Og -g -fvar-tracking-assignments"
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/build.sh
+++ b/cross-compilers/gcc/build.sh
@@ -1,4 +1,4 @@
-CHOST="x86_64-sarc-linux-gnu"
+CHOST="${arch}-${vendor}-linux-${libc}"
 mkdir -p .build/src
 mkdir -p .build/tarballs
 if [[ ! -e ".build/tarballs/linux-2.6.18.tar.xz" ]]; then
@@ -16,7 +16,7 @@ fi
 # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=31827
 ulimit -s 32768
 
-# pushd .build/x86_64-sarc-linux-gnu/build/build-cc-gcc-final
+# pushd .build/${CHOST}/build/build-cc-gcc-final
 # make -k check || true
 # popd
 

--- a/cross-compilers/gcc/build.sh
+++ b/cross-compilers/gcc/build.sh
@@ -1,6 +1,4 @@
 CHOST="x86_64-sarc-linux-gnu"
-
-echo $(pwd)
 mkdir -p .build/src
 mkdir -p .build/tarballs
 if [[ ! -e ".build/tarballs/linux-2.6.18.tar.xz" ]]; then
@@ -9,8 +7,8 @@ fi
 
 cp $RECIPE_DIR/.config .config
 
-# If the binary doesn't exist yet, then run ct-ng
-if [[ ! -e "${SRC_DIR}/gcc_built/bin/x86_64-sarc-linux-gnu-gcc" ]]; then
+# If dirty is unset or the binary doesn't exist yet, then run ct-ng
+if [[ ! -e "${SRC_DIR}/gcc_built/bin/${CHOST}-gcc" ]]; then
    ct-ng build;
 fi
 

--- a/cross-compilers/gcc/build.sh
+++ b/cross-compilers/gcc/build.sh
@@ -1,3 +1,5 @@
+CHOST="x86_64-sarc-linux-gnu"
+
 echo $(pwd)
 mkdir -p .build/src
 mkdir -p .build/tarballs
@@ -7,15 +9,19 @@ fi
 
 cp $RECIPE_DIR/.config .config
 
-# If dirty is unset or the binary doesn't exist yet, then run ct-ng
-if [[ -z ${DIRTY+x} || ! -e "${PREFIX}/bin/x86_64-sarc-linux-gnueabi-gcc" ]]; then
+# If the binary doesn't exist yet, then run ct-ng
+if [[ ! -e "${SRC_DIR}/gcc_built/bin/x86_64-sarc-linux-gnu-gcc" ]]; then
    ct-ng build;
 fi
 
-chmod 755 $PREFIX
+# increase stack size to prevent test failures
+# http://gcc.gnu.org/bugzilla/show_bug.cgi?id=31827
+ulimit -s 32768
 
-mkdir -p $PREFIX/etc/conda/activate.d
-cp $RECIPE_DIR/activate.sh $PREFIX/etc/conda/activate.d/compiler_linux-64_linux-cos5-64-activate.sh
+# pushd .build/x86_64-sarc-linux-gnu/build/build-cc-gcc-final
+# make -k check || true
+# popd
 
-mkdir -p $PREFIX/etc/conda/deactivate.d
-cp $RECIPE_DIR/deactivate.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-64_linux-cos5-64-deactivate.sh
+# .build/src/gcc-${PKG_VERSION}/contrib/test_summary
+
+chmod 755 -R $PREFIX

--- a/cross-compilers/gcc/conda_build_config.yaml
+++ b/cross-compilers/gcc/conda_build_config.yaml
@@ -1,4 +1,4 @@
-arch:
+cpu_arch:
   - x86_64
 libc:
   - gnu

--- a/cross-compilers/gcc/conda_build_config.yaml
+++ b/cross-compilers/gcc/conda_build_config.yaml
@@ -1,0 +1,28 @@
+arch:
+  - x86_64
+libc:
+  - gnu
+binutils:
+  - 2.26
+glibc:
+  - 2.5
+kernel:
+  - 2.6.18
+gcc:
+  - 6.3.0
+gmp:
+  - 6.1.2
+mpfr:
+  - 3.1.5
+gettext:
+  - 0.19.7
+libiconv:
+  - 1.14
+isl:
+  - 0.16.1
+mpc:
+  - 1.0.3
+ncurses:
+  - 6.0
+vendor:
+  - cio

--- a/cross-compilers/gcc/deactivate-binutils.sh
+++ b/cross-compilers/gcc/deactivate-binutils.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
+#  exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/deactivate-binutils.sh
+++ b/cross-compilers/gcc/deactivate-binutils.sh
@@ -73,14 +73,7 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
-
+  addr2line ar as c++filt elfedit gprof ld ldd nm objcopy objdump ranlib readelf size strings strip
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-binutils.sh
+++ b/cross-compilers/gcc/deactivate-binutils.sh
@@ -70,10 +70,13 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++filt elfedit gprof ld ldd nm objcopy objdump ranlib readelf size strings strip
+  deactivate host ${CHOST} ${CHOST}- \
+  addr2line ar as c++filt elfedit gprof ld nm objcopy objdump ranlib readelf size strings strip \
+  # dummy variable, I think.  Mostly because I don't know exactly how this script works
+  BINUTILS_VER,${BINUTILS_VER:-"2.26"} \
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-binutils.sh
+++ b/cross-compilers/gcc/deactivate-binutils.sh
@@ -74,9 +74,7 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host ${CHOST} ${CHOST}- \
-  addr2line ar as c++filt elfedit gprof ld nm objcopy objdump ranlib readelf size strings strip \
-  # dummy variable, I think.  Mostly because I don't know exactly how this script works
-  BINUTILS_VER,${BINUTILS_VER:-"2.26"} \
+  addr2line ar as c++filt elfedit gprof ld nm objcopy objdump ranlib readelf size strings strip
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-g++.sh
+++ b/cross-compilers/gcc/deactivate-g++.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
+#  exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/deactivate-g++.sh
+++ b/cross-compilers/gcc/deactivate-g++.sh
@@ -73,12 +73,9 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  c++ cpp g++ \
   CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
   CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
   DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
@@ -87,6 +84,6 @@ if [ $? -ne 0 ]; then
 #  exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu-g++' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/deactivate-g++.sh
+++ b/cross-compilers/gcc/deactivate-g++.sh
@@ -74,11 +74,9 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host ${CHOST} ${CHOST}- \
-  c++ cpp g++ \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
-
+  c++ g++ \
+  "CXXFLAGS,${CXXFLAGS:--march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11}" \
+  "DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:--Og -g -fPIC -fvar-tracking-assignments}"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-g++.sh
+++ b/cross-compilers/gcc/deactivate-g++.sh
@@ -70,9 +70,10 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  deactivate host ${CHOST} ${CHOST}- \
   c++ cpp g++ \
   CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
   CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \

--- a/cross-compilers/gcc/deactivate-gcc.sh
+++ b/cross-compilers/gcc/deactivate-gcc.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
+#  exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/deactivate-gcc.sh
+++ b/cross-compilers/gcc/deactivate-gcc.sh
@@ -74,10 +74,11 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host ${CHOST} ${CHOST}- \
-  gcc gcc-ar gcc-nm gcc-ranlib \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"}
+  cpp gcc gcc-ar gcc-nm gcc-ranlib \
+  "CFLAGS,${CFLAGS:--march=nocona -fPIC -fvisibility=hidden -O2 -pipe -fstack-protector-strong}" \
+  "CPPFLAGS,${CPPFLAGS:--D_FORTIFY_SOURCE=2}" \
+  "LDFLAGS,${LDFLAGS:--Wl,-O1,--sort-common,--as-needed,-z,relro}" \
+  "DEBUG_CFLAGS,${DEBUG_CFLAGS:--Og -g -fPIC -fvar-tracking-assignments}"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-gcc.sh
+++ b/cross-compilers/gcc/deactivate-gcc.sh
@@ -70,9 +70,10 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  deactivate host ${CHOST} ${CHOST}- \
   gcc gcc-ar gcc-nm gcc-ranlib \
   CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
   LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \

--- a/cross-compilers/gcc/deactivate-gcc.sh
+++ b/cross-compilers/gcc/deactivate-gcc.sh
@@ -73,20 +73,16 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  gcc gcc-ar gcc-nm gcc-ranlib \
   CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
   LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
-
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
 #  exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu-gcc' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/deactivate-gfortran.sh
+++ b/cross-compilers/gcc/deactivate-gfortran.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# The arguments to this are:
+# 1. activation nature {activate|deactivate}
+# 2. toolchain nature {build|host|ccc}
+# 3. machine (should match -dumpmachine)
+# 4. prefix (including any final -)
+# 5+ program (or environment var comma value)
+# The format for 5+ is name{,,value}. If value is specified
+#  then name taken to be an environment variable, otherwise
+#  it is taken to be a program. In this case, which is used
+#  to find the full filename during activation. The original
+#  value is stored in environment variable CONDA_BACKUP_NAME
+#  For deactivation, the distinction is irrelevant as in all
+#  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
+#  a fatal error if a program is identified but not present.
+function _tc_activation() {
+  local act_nature=$1; shift
+  local tc_nature=$1; shift
+  local tc_machine=$1; shift
+  local tc_prefix=$1; shift
+  local thing
+  local newval
+  local from
+  local to
+  local which
+  local pass
+
+  if [ "${act_nature}" = "activate" ]; then
+    from=""
+    to="CONDA_BACKUP_"
+  else
+    from="CONDA_BACKUP_"
+    to=""
+  fi
+
+  for pass in check apply; do
+    for thing in $tc_nature,$tc_machine "$@"; do
+      case "${thing}" in
+        *,*)
+          newval=$(echo "${thing}" | sed "s,^[^\,]*\,\(.*\),\1,")
+          thing=$(echo "${thing}" | sed "s,^\([^\,]*\)\,.*,\1,")
+          ;;
+        *)
+          newval=$(which ${CONDA_PREFIX}/bin/${tc_prefix}${thing} 2>/dev/null)
+          if [ -z "${newval}" -a "${pass}" = "check" ]; then
+            echo "ERROR: This cross-compiler package contains no program ${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
+            return 1
+          fi
+          ;;
+      esac
+      if [ "${pass}" = "apply" ]; then
+        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        eval oldval="\$${from}$thing"
+        if [ -n "${oldval}" ]; then
+          eval export "${to}'${thing}'=\"${oldval}\""
+        else
+          eval unset '${to}${thing}'
+        fi
+        if [ -n "${newval}" ]; then
+          eval export "'${from}${thing}=${newval}'"
+        else
+          eval unset '${from}${thing}'
+        fi
+      fi
+    done
+  done
+  return 0
+}
+
+# We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
+# but uClibc has poor (or no) support for it.
+env > /tmp/old-env-$$.txt
+_tc_activation \
+  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
+
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
+#  exit 1
+else
+  env > /tmp/new-env-$$.txt
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
+fi

--- a/cross-compilers/gcc/deactivate-gfortran.sh
+++ b/cross-compilers/gcc/deactivate-gfortran.sh
@@ -73,20 +73,16 @@ function _tc_activation() {
 env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
-  addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
-  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
-  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
-  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
-  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
-  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
-
+  gfortran \
+  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
+  FORTRANFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
+  DEBUG_FFLAGS,${FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none"} \
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"
 #  exit 1
 else
   env > /tmp/new-env-$$.txt
-  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu' (pseudo) cross-compiler made the following environmental changes:"
+  echo "INFO: Deactivating 'x86_64-unknown-linux-gnu-gfortran' (pseudo) cross-compiler made the following environmental changes:"
   diff -U 0 -rN /tmp/old-env-$$.txt /tmp/new-env-$$.txt | tail -n +4 | grep "^-.*\|^+.*" | grep -v "CONDA_BACKUP_" | sort
 fi

--- a/cross-compilers/gcc/deactivate-gfortran.sh
+++ b/cross-compilers/gcc/deactivate-gfortran.sh
@@ -75,9 +75,9 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host ${CHOST} ${CHOST}- \
   gfortran \
-  FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
-  FORTRANFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
-  DEBUG_FFLAGS,${FFLAGS:-"-Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none"} \
+  "FFLAGS,${FFLAGS:--march=nocona -Wall -Wextra -fopenmp -fPIC -O3}" \
+  "FORTRANFLAGS,${FORTRANFLAGS:--march=nocona -Wall -Wextra -fopenmp -fPIC -O3}" \
+  "DEBUG_FFLAGS,${DEBUG_FFLAGS:--Og -g -Wall -Wextra -fcheck=all -fbacktrace -fPIC -fimplicit-none}"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: (Pseudo) cross-compiler deactivation failed, see above for details"

--- a/cross-compilers/gcc/deactivate-gfortran.sh
+++ b/cross-compilers/gcc/deactivate-gfortran.sh
@@ -70,9 +70,10 @@ function _tc_activation() {
 
 # We would like to add "-fstack-protector --param=ssp-buffer-size" to {C,CXX}FLAGS
 # but uClibc has poor (or no) support for it.
+# CHOST is prepended to this file by the install script.
 env > /tmp/old-env-$$.txt
 _tc_activation \
-  deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
+  deactivate host ${CHOST} ${CHOST}- \
   gfortran \
   FFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \
   FORTRANFLAGS,${FFLAGS:-"-march=nocona -Wall -Wextra -fopenmp -O3"} \

--- a/cross-compilers/gcc/deactivate.sh
+++ b/cross-compilers/gcc/deactivate.sh
@@ -74,12 +74,12 @@ env > /tmp/old-env-$$.txt
 _tc_activation \
   deactivate host x86_64-sarc-linux-gnu x86_64-sarc-linux-gnu- \
   addr2line ar as c++ cc c++filt cpp elfedit g++ gcc c++ gcov gcov-tool gfortran gprof ld ldd nm objcopy objdump ranlib readelf size strings strip \
-  CPPFLAGS,"-D_FORTIFY_SOURCE=2" \
-  CFLAGS,"-march=westmere -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong" \
-  CXXFLAGS,"-march=westmere -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11" \
-  LDFLAGS,"-Wl,-O1,--sort-common,--as-needed,-z,relro" \
-  DEBUG_CFLAGS,"-Og -g -fvar-tracking-assignments" \
-  DEBUG_CXXFLAGS,"-Og -g -fvar-tracking-assignments"
+  CPPFLAGS,${CPPFLAGS:-"-D_FORTIFY_SOURCE=2"} \
+  CFLAGS,${CFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong"} \
+  CXXFLAGS,${CXXFLAGS:-"-march=nocona -fPIC -pie -fPIE -fvisibility=hidden -O2 -pipe -fstack-protector-strong -std=c++11"} \
+  LDFLAGS,${LDFLAGS:-"-Wl,-O1,--sort-common,--as-needed,-z,relro"} \
+  DEBUG_CFLAGS,${DEBUG_CFLAGS:-"-Og -g -fvar-tracking-assignments"} \
+  DEBUG_CXXFLAGS,${DEBUG_CXXFLAGS:-"-Og -g -fvar-tracking-assignments"}
 
 
 if [ $? -ne 0 ]; then

--- a/cross-compilers/gcc/install-binutils.sh
+++ b/cross-compilers/gcc/install-binutils.sh
@@ -1,5 +1,8 @@
 set -e -x
-CHOST="x86_64-sarc-linux-gnu"
+
+CHOST="x86_64-${vendor}-linux-gnu"
+PACKAGE="binutils"
+
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
 
@@ -8,7 +11,7 @@ make prefix=$PREFIX install
 popd
 
 mkdir -p $PREFIX/etc/conda/activate.d
-cp $RECIPE_DIR/activate-binutils.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-binutils.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-cp $RECIPE_DIR/deactivate-binutils.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-binutils.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh

--- a/cross-compilers/gcc/install-binutils.sh
+++ b/cross-compilers/gcc/install-binutils.sh
@@ -1,12 +1,14 @@
 set -e -x
+CHOST="x86_64-sarc-linux-gnu"
+# libtool wants to use ranlib that is here
+export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
 
-pushd $SRC_DIR/.build/x86_64-sarc-linux-gnu/build/build-binutils-host-x86_64-build_redhat-linux-gnu6E
-make DESTDIR=$PREFIX install
+pushd $SRC_DIR/.build/$CHOST/build/build-binutils-host-x86_64-build_redhat-linux-gnu6E
+make prefix=$PREFIX install
 popd
 
-# since binutils is a req for all compilers, we bundle the activate scripts here.
 mkdir -p $PREFIX/etc/conda/activate.d
-cp $RECIPE_DIR/activate.sh $PREFIX/etc/conda/activate.d/compiler_linux-64_linux-cos5-64-activate.sh
+cp $RECIPE_DIR/activate-binutils.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-binutils.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-cp $RECIPE_DIR/deactivate.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-64_linux-cos5-64-deactivate.sh
+cp $RECIPE_DIR/deactivate-binutils.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-binutils.sh

--- a/cross-compilers/gcc/install-binutils.sh
+++ b/cross-compilers/gcc/install-binutils.sh
@@ -1,7 +1,6 @@
 set -e -x
 
-CHOST="x86_64-${vendor}-linux-gnu"
-PACKAGE="binutils"
+CHOST="${arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
@@ -11,7 +10,7 @@ make prefix=$PREFIX install
 popd
 
 mkdir -p $PREFIX/etc/conda/activate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-binutils.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PKG_NAME}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-binutils.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh

--- a/cross-compilers/gcc/install-binutils.sh
+++ b/cross-compilers/gcc/install-binutils.sh
@@ -1,3 +1,12 @@
-pushd $SRC_DIR/.build/aarch64-sarc-linux-gnueabi/build/build-binutils-host-x86_64-build_redhat-linux-gnu6E
+set -e -x
+
+pushd $SRC_DIR/.build/x86_64-sarc-linux-gnu/build/build-binutils-host-x86_64-build_redhat-linux-gnu6E
 make DESTDIR=$PREFIX install
 popd
+
+# since binutils is a req for all compilers, we bundle the activate scripts here.
+mkdir -p $PREFIX/etc/conda/activate.d
+cp $RECIPE_DIR/activate.sh $PREFIX/etc/conda/activate.d/compiler_linux-64_linux-cos5-64-activate.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/deactivate.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-64_linux-cos5-64-deactivate.sh

--- a/cross-compilers/gcc/install-binutils.sh
+++ b/cross-compilers/gcc/install-binutils.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin

--- a/cross-compilers/gcc/install-g++.sh
+++ b/cross-compilers/gcc/install-g++.sh
@@ -1,3 +1,32 @@
-pushd $SRC_DIR/.build/aarch64-sarc-linux-gnueabi/build/build-cc-gcc-final/
-make DESTDIR=$PREFIX install g++
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+
+# libtool wants to use ranlib that is here
+export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
+
+pushd ${SRC_DIR}/.build/$CHOST/build/build-cc-gcc-final/
+
+make -C gcc prefix=${PREFIX} install-cpp c++.install-common install-lto-wrapper
+make -C lto-plugin prefix=${PREFIX} install
+install -dm755 ${PREFIX}/lib/bfd-plugins/
+
+# statically linked, so this so does not exist
+# ln -s $PREFIX/lib/gcc/$CHOST/liblto_plugin.so ${PREFIX}/lib/bfd-plugins/
+
+install -m755 -t ${PREFIX}/bin/ gcc/{cc1plus,lto1}
+
+make -C $CHOST/libstdc++-v3/src prefix=${PREFIX} install
+make -C $CHOST/libstdc++-v3/include prefix=${PREFIX} install
+make -C $CHOST/libstdc++-v3/libsupc++ prefix=${PREFIX} install
+make -C $CHOST/libstdc++-v3/python prefix=${PREFIX} install
+
+mkdir -p ${PREFIX}/share/gdb/auto-load/usr/lib/
+cp ${SRC_DIR}/gcc_built/${CHOST}/sysroot/lib/libstdc++.so.6.*-gdb.py ${PREFIX}/share/gdb/auto-load/usr/lib/
+
+make -C libcpp prefix=${PREFIX} install
+
 popd
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-g++.sh
+++ b/cross-compilers/gcc/install-g++.sh
@@ -1,6 +1,7 @@
 set -e -x
 
-CHOST="x86_64-sarc-linux-gnu"
+CHOST="x86_64-${vendor}-linux-gnu"
+PACKAGE="g++"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
@@ -32,7 +33,7 @@ install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
 
 mkdir -p $PREFIX/etc/conda/activate.d
-cp $RECIPE_DIR/activate-g++.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-g++.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-cp $RECIPE_DIR/deactivate-g++.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-g++.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh

--- a/cross-compilers/gcc/install-g++.sh
+++ b/cross-compilers/gcc/install-g++.sh
@@ -1,7 +1,6 @@
 set -e -x
 
-CHOST="x86_64-${vendor}-linux-gnu"
-PACKAGE="g++"
+CHOST="${arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
@@ -33,7 +32,7 @@ install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
 
 mkdir -p $PREFIX/etc/conda/activate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-g++.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PKG_NAME}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-g++.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh

--- a/cross-compilers/gcc/install-g++.sh
+++ b/cross-compilers/gcc/install-g++.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin

--- a/cross-compilers/gcc/install-g++.sh
+++ b/cross-compilers/gcc/install-g++.sh
@@ -30,3 +30,9 @@ popd
 # Install Runtime Library Exception
 install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
+
+mkdir -p $PREFIX/etc/conda/activate.d
+cp $RECIPE_DIR/activate-g++.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-g++.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/deactivate-g++.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-g++.sh

--- a/cross-compilers/gcc/install-gcc.sh
+++ b/cross-compilers/gcc/install-gcc.sh
@@ -1,3 +1,73 @@
-pushd $SRC_DIR/.build/aarch64-sarc-linux-gnueabi/build/build-cc-gcc-final/
-make DESTDIR=$PREFIX install gcc
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+pushd ${SRC_DIR}/.build/$CHOST/build/build-cc-gcc-final/
+
+# libtool wants to use ranlib that is here
+export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
+
+make -C gcc prefix=${PREFIX} install-driver install-gcc-ar install-headers install-plugin
+
+install -m755 -t ${PREFIX}/bin/ gcc/gcov{,-tool}
+install -m755 -t ${PREFIX}/bin/ gcc/{cc1,collect2}
+
+make -C $CHOST/libgcc prefix=${PREFIX} install
+# rm ${PREFIX}/lib/libgcc_s.so*
+
+make prefix=${PREFIX} install-libcc1
+install -d ${PREFIX}/share/gdb/auto-load/usr/lib
+
+make DESTDIR=${PREFIX} install-fixincludes
+make -C gcc DESTDIR=${PREFIX} install-mkheaders
+
+make -C $CHOST/libgomp prefix=${PREFIX} install-nodist_toolexeclibHEADERS \
+install-nodist_libsubincludeHEADERS
+# make -C $CHOST/libitm DESTDIR=${PREFIX} install-nodist_toolexeclibHEADERS
+make -C $CHOST/libquadmath prefix=${PREFIX} install-nodist_libsubincludeHEADERS
+# make -C $CHOST/libsanitizer DESTDIR=${PREFIX} install-nodist_{saninclude,toolexeclib}HEADERS
+# make -C $CHOST/libsanitizer/asan DESTDIR=${PREFIX} install-nodist_toolexeclibHEADERS
+
+make -C libiberty prefix=${PREFIX} install
+# install PIC version of libiberty
+install -m644 libiberty/pic/libiberty.a ${PREFIX}/lib
+
+make -C gcc prefix=${PREFIX} install-man install-info
+
+make -C gcc prefix=${PREFIX} install-po
+
+# many packages expect this symlink
+ln -s ${PREFIX}/bin/x86_64-sarc-linux-gnu-gcc ${PREFIX}/bin/cc
+
+# POSIX conformance launcher scripts for c89 and c99
+cat > ${PREFIX}/bin/c89 <<"EOF"
+#!/bin/sh
+fl="-std=c89"
+for opt; do
+  case "$opt" in
+    -ansi|-std=c89|-std=iso9899:1990) fl="";;
+    -std=*) echo "`basename $0` called with non ANSI/ISO C option $opt" >&2
+      exit 1;;
+  esac
+done
+exec gcc $fl ${1+"$@"}
+EOF
+
+  cat > ${PREFIX}/bin/c99 <<"EOF"
+#!/bin/sh
+fl="-std=c99"
+for opt; do
+  case "$opt" in
+    -std=c99|-std=iso9899:1999) fl="";;
+    -std=*) echo "`basename $0` called with non ISO C99 option $opt" >&2
+      exit 1;;
+  esac
+done
+exec gcc $fl ${1+"$@"}
+EOF
+
+  chmod 755 ${PREFIX}/bin/c{8,9}9
+
 popd
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-gcc.sh
+++ b/cross-compilers/gcc/install-gcc.sh
@@ -1,7 +1,6 @@
 set -e -x
 
-CHOST="x86_64-${vendor}-linux-gnu"
-PACKAGE="gcc"
+CHOST="${arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
@@ -86,7 +85,7 @@ install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc/RUNTIME.LIBRARY.EXCEPTION
 
 mkdir -p $PREFIX/etc/conda/activate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-gcc.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PKG_NAME}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-gcc.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh

--- a/cross-compilers/gcc/install-gcc.sh
+++ b/cross-compilers/gcc/install-gcc.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin

--- a/cross-compilers/gcc/install-gcc.sh
+++ b/cross-compilers/gcc/install-gcc.sh
@@ -1,11 +1,10 @@
 set -e -x
-
-CHOST="x86_64-sarc-linux-gnu"
-pushd ${SRC_DIR}/.build/$CHOST/build/build-cc-gcc-final/
-
 # libtool wants to use ranlib that is here
 export PATH=$PATH:${SRC_DIR}/.build/$CHOST/buildtools/bin
 
+CHOST="x86_64-sarc-linux-gnu"
+
+pushd ${SRC_DIR}/.build/$CHOST/build/build-cc-gcc-final/
 make -C gcc prefix=${PREFIX} install-driver install-gcc-ar install-headers install-plugin
 
 install -m755 -t ${PREFIX}/bin/ gcc/gcov{,-tool}
@@ -67,7 +66,19 @@ EOF
 
   chmod 755 ${PREFIX}/bin/c{8,9}9
 
+# duplicate executable - taking up space?  Is it a hardlink?
+# rm $PREFIX/bin/${CHOST}-gcc-${PKG_VERSION}
+
+mkdir -p $PREFIX/$CHOST
+cp -r ${SRC_DIR}/gcc_built/${CHOST}/sysroot/include $PREFIX/${CHOST}
+
 popd
 # Install Runtime Library Exception
 install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
-        ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
+        ${PREFIX}/share/licenses/gcc/RUNTIME.LIBRARY.EXCEPTION
+
+mkdir -p $PREFIX/etc/conda/activate.d
+cp $RECIPE_DIR/activate-gcc.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-gcc.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/deactivate-gcc.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-gcc.sh

--- a/cross-compilers/gcc/install-gfortran.sh
+++ b/cross-compilers/gcc/install-gfortran.sh
@@ -1,9 +1,6 @@
 set -e -x
 
-
-CHOST="x86_64-${vendor}-linux-gnu"
-PACKAGE="gfortran"
-
+CHOST="${arch}-${vendor}-linux-${libc}"
 
 _libdir="libexec/gcc/$CHOST/$PKG_VERSION"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
@@ -26,7 +23,7 @@ install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
 
 mkdir -p $PREFIX/etc/conda/activate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-gfortran.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PKG_NAME}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-gfortran.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PKG_NAME}.sh

--- a/cross-compilers/gcc/install-gfortran.sh
+++ b/cross-compilers/gcc/install-gfortran.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 
 _libdir="libexec/gcc/$CHOST/$PKG_VERSION"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/

--- a/cross-compilers/gcc/install-gfortran.sh
+++ b/cross-compilers/gcc/install-gfortran.sh
@@ -18,3 +18,9 @@ popd
 # Install Runtime Library Exception
 install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
+
+mkdir -p $PREFIX/etc/conda/activate.d
+cp $RECIPE_DIR/activate-gfortran.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-gfortran.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/deactivate-gfortran.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-gfortran.sh

--- a/cross-compilers/gcc/install-gfortran.sh
+++ b/cross-compilers/gcc/install-gfortran.sh
@@ -1,7 +1,11 @@
 set -e -x
 
-CHOST="x86_64-sarc-linux-gnu"
-_libdir="lib/gcc/$CHOST/$PKG_VERSION"
+
+CHOST="x86_64-${vendor}-linux-gnu"
+PACKAGE="gfortran"
+
+
+_libdir="libexec/gcc/$CHOST/$PKG_VERSION"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
 
 # adapted from Arch install script from https://github.com/archlinuxarm/PKGBUILDs/blob/master/core/gcc/PKGBUILD
@@ -11,7 +15,9 @@ make -C $CHOST/libgomp prefix=$PREFIX install-nodist_fincludeHEADERS
 make -C gcc prefix=$PREFIX fortran.install-{common,man,info}
 install -Dm755 gcc/f951 $PREFIX/${_libdir}/f951
 
-ln -s $PREFIX/bin/$CHOST-gfortran $PREFIX/bin/f95
+if [ ! -e ${PREFIX}/bin/f95 ]; then
+    ln -s $PREFIX/bin/$CHOST-gfortran $PREFIX/bin/f95
+fi
 
 popd
 
@@ -20,7 +26,7 @@ install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
 
 mkdir -p $PREFIX/etc/conda/activate.d
-cp $RECIPE_DIR/activate-gfortran.sh $PREFIX/etc/conda/activate.d/compiler_linux-cos5-64-activate-gfortran.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/activate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/activate.d/activate-${PACKAGE}-${CHOST}.sh
 
 mkdir -p $PREFIX/etc/conda/deactivate.d
-cp $RECIPE_DIR/deactivate-gfortran.sh $PREFIX/etc/conda/deactivate.d/compiler_linux-cos5-64-deactivate-gfortran.sh
+echo "export CHOST=${CHOST}" | cat - $RECIPE_DIR/deactivate-${PACKAGE}.sh > /tmp/out && mv /tmp/out $PREFIX/etc/conda/deactivate.d/deactivate-${PACKAGE}-${CHOST}.sh

--- a/cross-compilers/gcc/install-gfortran.sh
+++ b/cross-compilers/gcc/install-gfortran.sh
@@ -1,0 +1,20 @@
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+_libdir="lib/gcc/$CHOST/$PKG_VERSION"
+pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
+
+# adapted from Arch install script from https://github.com/archlinuxarm/PKGBUILDs/blob/master/core/gcc/PKGBUILD
+make -C $CHOST/libgfortran prefix=$PREFIX install-cafexeclibLTLIBRARIES \
+     install-{toolexeclibDATA,nodist_fincludeHEADERS}
+make -C $CHOST/libgomp prefix=$PREFIX install-nodist_fincludeHEADERS
+make -C gcc prefix=$PREFIX fortran.install-{common,man,info}
+install -Dm755 gcc/f951 $PREFIX/${_libdir}/f951
+
+ln -s $PREFIX/bin/$CHOST-gfortran $PREFIX/bin/f95
+
+popd
+
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-libgcc.sh
+++ b/cross-compilers/gcc/install-libgcc.sh
@@ -1,3 +1,40 @@
-pushd $SRC_DIR/.build/aarch64-sarc-linux-gnueabi/build/build-cc-gcc-final/
-make DESTDIR=$PREFIX install libgcc
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
+
+make -C $CHOST/libgcc prefix=${PREFIX} install-shared
+
+# omits:
+# libitm \
+# libvtv \
+# libsanitizer/{a,l,ub}san \
+
+for lib in libatomic libgomp libquadmath; do
+    make -C $CHOST/$lib prefix=${PREFIX} install-toolexeclibLTLIBRARIES
+done
+
+# make -C $CHOST/libsanitizer/tsan DESTDIR=${PREFIX} install-toolexeclibLTLIBRARIES
+
+# omits:
+# libitm \
+
+for lib in libgomp libquadmath; do
+    make -C $CHOST/$lib prefix=${PREFIX} install-info
+done
+
 popd
+
+mkdir -p $PREFIX/lib
+mv $PREFIX/$CHOST/lib/* $PREFIX/lib
+
+# no static libs
+find $PREFIX/lib -name "*\.a" -exec rm -rf {} \;
+# no libtool files
+find $PREFIX/lib -name "*\.la" -exec rm -rf {} \;
+# clean up empty folder
+rm -rf $PREFIX/lib/gcc
+
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-libgcc.sh
+++ b/cross-compilers/gcc/install-libgcc.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
 
 make -C $CHOST/libgcc prefix=${PREFIX} install-shared

--- a/cross-compilers/gcc/install-libgcc.sh
+++ b/cross-compilers/gcc/install-libgcc.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="x86_64-sarc-linux-gnu"
+CHOST="${arch}-${vendor}-linux-${libc}"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
 
 make -C $CHOST/libgcc prefix=${PREFIX} install-shared

--- a/cross-compilers/gcc/install-libgfortran.sh
+++ b/cross-compilers/gcc/install-libgfortran.sh
@@ -1,0 +1,12 @@
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+
+mkdir -p $PREFIX/lib
+cp ${SRC_DIR}/gcc_built/$CHOST/sysroot/lib/libgfortran.so.3.0.0 $PREFIX/lib
+ln -s $PREFIX/lib/libgfortran.so.3.0.0 $PREFIX/lib/libgfortran.so.3
+ln -s $PREFIX/lib/libgfortran.so.3.0.0 $PREFIX/lib/libgfortran.so
+
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-libgfortran.sh
+++ b/cross-compilers/gcc/install-libgfortran.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 
 mkdir -p $PREFIX/lib
 cp ${SRC_DIR}/gcc_built/$CHOST/sysroot/lib/libgfortran.so.3.0.0 $PREFIX/lib

--- a/cross-compilers/gcc/install-libgfortran.sh
+++ b/cross-compilers/gcc/install-libgfortran.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="x86_64-sarc-linux-gnu"
+CHOST="${arch}-${vendor}-linux-${libc}"
 
 mkdir -p $PREFIX/lib
 cp ${SRC_DIR}/gcc_built/$CHOST/sysroot/lib/libgfortran.so.3.0.0 $PREFIX/lib

--- a/cross-compilers/gcc/install-libstdc++.sh
+++ b/cross-compilers/gcc/install-libstdc++.sh
@@ -1,3 +1,21 @@
-pushd $SRC_DIR/.build/aarch64-sarc-linux-gnueabi/build/build-cc-gcc-final/
-make DESTDIR=$PREFIX install libstdc++
+set -e -x
+
+CHOST="x86_64-sarc-linux-gnu"
+pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
+
+make -C $CHOST/libstdc++-v3/src prefix=${PREFIX} install-toolexeclibLTLIBRARIES
+make -C $CHOST/libstdc++-v3/po prefix=${PREFIX} install
+
 popd
+
+mkdir -p $PREFIX/lib
+mv $PREFIX/$CHOST/lib/* $PREFIX/lib
+
+# no static libs
+find $PREFIX/lib -name "*\.a" -exec rm -rf {} \;
+# no libtool files
+find $PREFIX/lib -name "*\.la" -exec rm -rf {} \;
+
+# Install Runtime Library Exception
+install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
+        ${PREFIX}/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION

--- a/cross-compilers/gcc/install-libstdc++.sh
+++ b/cross-compilers/gcc/install-libstdc++.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="x86_64-sarc-linux-gnu"
+CHOST="${arch}-${vendor}-linux-${libc}"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
 
 make -C $CHOST/libstdc++-v3/src prefix=${PREFIX} install-toolexeclibLTLIBRARIES

--- a/cross-compilers/gcc/install-libstdc++.sh
+++ b/cross-compilers/gcc/install-libstdc++.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-CHOST="${arch}-${vendor}-linux-${libc}"
+CHOST="${cpu_arch}-${vendor}-linux-${libc}"
 pushd $SRC_DIR/.build/$CHOST/build/build-cc-gcc-final/
 
 make -C $CHOST/libstdc++-v3/src prefix=${PREFIX} install-toolexeclibLTLIBRARIES

--- a/cross-compilers/gcc/meta.yaml
+++ b/cross-compilers/gcc/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: compilers_linux-64_linux-cos5-64
+  name: compilers_linux-cos5-64
   version: 6.3.0
 
 source:
@@ -14,39 +14,40 @@ requirements:
     - crosstool-ng  11a11abe
     - unifdef
   run:
-    - gcc_linux-64_linux-cos5-64
-    - g++_linux-64_linux-cos5-64
-    - gfortran_linux-64_linux-cos5-64
+    - gcc_linux-cos5-64
+    - gxx_linux-cos5-64
+    - gfortran_linux-cos5-64
 
 outputs:
-  - name: gcc_linux-64_linux-cos5-64
+  - name: gcc_linux-cos5-64
     script: install-gcc.sh
     requirements:
-      - binutils_linux-64_linux-cos5-64
+      - binutils_linux-cos5-64
     # needs "build_customization branch
     # pin_downstream:
     #   - {{ pin_subpackage('libgcc_linux-cos5-64') }}
 
-  - name: g++_linux-64_linux-cos5-64
+  - name: gxx_linux-cos5-64
     script: install-g++.sh
     requirements:
-      - gcc_linux-64_linux-cos5-64
+      - gcc_linux-cos5-64
     # needs "build_customization branch
     # pin_downstream:
-    #   - {{ pin_subpackage('libstdc++_linux-cos5-64') }}
+    #   - {{ pin_subpackage('libstdcxx_linux-cos5-64') }}
 
-  - name: gfortran_linux-64_linux-cos5-64
+  - name: gfortran_linux-cos5-64
     script: install-gfortran.sh
     requirements:
-      - gcc_linux-64_linux-cos5-64
+      - gcc_linux-cos5-64
     # needs "build_customization branch
     # pin_downstream:
     #   - {{ pin_subpackage('libgfortran_linux-cos5-64') }}
 
-  - name: binutils_linux-64-cos5-64
+  - name: binutils_linux-cos5-64
     script: install-binutils.sh
+    version: 2.26
 
-  - name: libstdc++_linux-cos5-64
+  - name: libstdcxx_linux-cos5-64
     script: install-libstdc++.sh
 
   - name: libgcc_linux-cos5-64

--- a/cross-compilers/gcc/meta.yaml
+++ b/cross-compilers/gcc/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: gcc_linux-64_linux-cos5-64
+  name: compilers_linux-64_linux-cos5-64
   version: 6.3.0
 
 source:
@@ -7,23 +7,50 @@ source:
 
 build:
   detect_binary_files_with_prefix: False
+  binary_relocation: False
 
 requirements:
   build:
     - crosstool-ng  11a11abe
+    - unifdef
+  run:
+    - gcc_linux-64_linux-cos5-64
+    - g++_linux-64_linux-cos5-64
+    - gfortran_linux-64_linux-cos5-64
 
-# outputs:
-#   - name: gcc_linux-64_linux-aarch64
-#     script: install-gcc.sh
-#     requirements:
-#       - binutils_linux-64_linux-aarch64
-#   - name: g++_linux-64_linux-aarch64
-#     script: install-g++.sh
-#     requirements:
-#       - binutils_linux-64_linux-aarch64
-#   - name: binutils_linux-64-aarch64
-#     script: install-binutils.sh
-#   - name: libstdc++_linux-aarch64
-#     script: install-libstdc++.sh
-#   - name: libgcc_linux-aarch64
-#     script: install-libgcc.sh
+outputs:
+  - name: gcc_linux-64_linux-cos5-64
+    script: install-gcc.sh
+    requirements:
+      - binutils_linux-64_linux-cos5-64
+    # needs "build_customization branch
+    # pin_downstream:
+    #   - {{ pin_subpackage('libgcc_linux-cos5-64') }}
+
+  - name: g++_linux-64_linux-cos5-64
+    script: install-g++.sh
+    requirements:
+      - gcc_linux-64_linux-cos5-64
+    # needs "build_customization branch
+    # pin_downstream:
+    #   - {{ pin_subpackage('libstdc++_linux-cos5-64') }}
+
+  - name: gfortran_linux-64_linux-cos5-64
+    script: install-gfortran.sh
+    requirements:
+      - gcc_linux-64_linux-cos5-64
+    # needs "build_customization branch
+    # pin_downstream:
+    #   - {{ pin_subpackage('libgfortran_linux-cos5-64') }}
+
+  - name: binutils_linux-64-cos5-64
+    script: install-binutils.sh
+
+  - name: libstdc++_linux-cos5-64
+    script: install-libstdc++.sh
+
+  - name: libgcc_linux-cos5-64
+    script: install-libgcc.sh
+
+  - name: libgfortran_linux-cos5-64
+    script: install-libgfortran.sh

--- a/cross-compilers/gcc/meta.yaml
+++ b/cross-compilers/gcc/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: compilers_linux-cos5-64
-  version: 6.3.0
+  version: {{ gcc }}
 
 source:
   path: .
@@ -23,29 +23,26 @@ outputs:
     script: install-gcc.sh
     requirements:
       - binutils_linux-cos5-64
-    # needs "build_customization branch
-    # pin_downstream:
-    #   - {{ pin_subpackage('libgcc_linux-cos5-64') }}
+    pin_downstream:
+      - {{ pin_subpackage('libgcc_linux-cos5-64') }}
 
   - name: gxx_linux-cos5-64
     script: install-g++.sh
     requirements:
       - gcc_linux-cos5-64
-    # needs "build_customization branch
-    # pin_downstream:
-    #   - {{ pin_subpackage('libstdcxx_linux-cos5-64') }}
+    pin_downstream:
+      - {{ pin_subpackage('libstdcxx_linux-cos5-64') }}
 
   - name: gfortran_linux-cos5-64
     script: install-gfortran.sh
     requirements:
       - gcc_linux-cos5-64
-    # needs "build_customization branch
-    # pin_downstream:
-    #   - {{ pin_subpackage('libgfortran_linux-cos5-64') }}
+    pin_downstream:
+      - {{ pin_subpackage('libgfortran_linux-cos5-64') }}
 
   - name: binutils_linux-cos5-64
     script: install-binutils.sh
-    version: 2.26
+    version: {{ binutils }}
 
   - name: libstdcxx_linux-cos5-64
     script: install-libstdc++.sh


### PR DESCRIPTION
For native gcc, change CPU -march from westmere (i3/i5/i7) to nocona (core 2).