### PR TITLE
compliers_generic: Two fixes

### DIFF
--- a/cross-compilers/compilers_generic/build.sh
+++ b/cross-compilers/compilers_generic/build.sh
@@ -53,7 +53,7 @@ if [[ ! -n $(find ${SRC_DIR}/gcc_built -iname ${cpu_arch}-${vendor}-*-gfortran) 
     source ${RECIPE_DIR}/write_ctng_config
 
     yes "" | ct-ng ${ctng_sample}
-    write_ctng_config_before "${PWD}"/.config
+    write_ctng_config_before .config
     # Apply some adjustments for conda.
     sed -i.bak "s|# CT_DISABLE_MULTILIB_LIB_OSDIRNAMES is not set|CT_DISABLE_MULTILIB_LIB_OSDIRNAMES=y|g" .config
     sed -i.bak "s|CT_CC_GCC_USE_LTO=n|CT_CC_GCC_USE_LTO=y|g" .config
@@ -71,8 +71,12 @@ if [[ ! -n $(find ${SRC_DIR}/gcc_built -iname ${cpu_arch}-${vendor}-*-gfortran) 
     fi
     # Now ensure any changes we made above pull in other requirements by running oldconfig.
     yes "" | ct-ng oldconfig
+    # Now filter out 'things that cause problems'. For example, depending on the base sample, you can end up with
+    # two different glibc versions in-play.
+    sed -i.bak '/CT_LIBC/d' .config
+    sed -i.bak '/CT_LIBC_GLIBC/d' .config
     # And undo any damage to version numbers => the seds above could be moved into this too probably.
-    write_ctng_config_after "${PWD}"/.config
+    write_ctng_config_after .config
     if cat .config | grep "CT_GDB_NATIVE=y"; then
       if ! cat .config | grep "CT_EXPAT_TARGET=y"; then
         echo "ERROR: CT_GDB_NATIVE=y but CT_EXPAT_TARGET!=y"

--- a/cross-compilers/compilers_generic/install-libgfortran.sh
+++ b/cross-compilers/compilers_generic/install-libgfortran.sh
@@ -9,11 +9,7 @@ export PATH=${SRC_DIR}/gcc_built/bin:${SRC_DIR}/.build/${CHOST}/buildtools/bin:$
 mkdir -p $PREFIX/lib
 rm -f $PREFIX/lib/libgfortran* || true
 
-cp ${SRC_DIR}/gcc_built/$CHOST/sysroot/lib/libgfortran.so.3.0.0 $PREFIX/lib
-pushd $PREFIX/lib
-  ln -s libgfortran.so.3.0.0 libgfortran.so.3.0
-  ln -s libgfortran.so.3.0 libgfortran.so
-popd
+cp -f ${SRC_DIR}/gcc_built/$CHOST/sysroot/lib/libgfortran.so* $PREFIX/lib
 
 # Install Runtime Library Exception
 install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \

--- a/cross-compilers/compilers_generic/write_ctng_config
+++ b/cross-compilers/compilers_generic/write_ctng_config
@@ -108,6 +108,10 @@ function write_ctng_package_versions() {
     "${_extras[@]}"; do
       write_config_var "${_dst}" "${_VAR_CT_VAR}"
   done
+  # Add this back here because build.sh filters out LIBC_GLIBC to prevent conflicts.
+  if [[ ${libc} == gnu ]]; then
+    echo "CT_LIBC_GLIBC_FORCE_UNWIND=y" >> "${_dst}"
+  fi
 }
 
 function write_ctng_config_before() {


### PR DESCRIPTION
1. Filter out problematic vars from the ct-ng sample
   (can end up with 2 glibc versions in play in different vars).
2. Fix libgfortran hard coding to version 3 (7.1 uses 4).