### PR TITLE
gsl: build with system compiler.

### DIFF
--- a/gsl/meta.yaml
+++ b/gsl/meta.yaml
@@ -8,14 +8,12 @@ source:
   md5: d8f70abafd3e9f0bae03c52d1f4e8de5
 
 build:
-  number: 1
+  number: 2
 
 requirements:
-  build:
-    - gcc
-
-  run:
-    - libgcc
+  # Build gsl with system compiler.  Do not use conda "gcc" nor
+  # "libgcc" packages as they may install shared libraries that
+  # are incompatible with their system version.
 
 about:
   home: http://www.gnu.org/software/gsl/


### PR DESCRIPTION
Avoid linking with possibly non-compatible shared libraries from
conda "gcc" or "libgcc" packages.  Using system compiler keeps
GSL compatible with other packages built with standard system
tools.

This partially reverts 40e929cee7f8453d173818d36420879706046c32.