### PR TITLE
Support building cvxopt on Linux.

### DIFF
--- a/cvxopt/build.sh
+++ b/cvxopt/build.sh
@@ -13,16 +13,9 @@ export CVXOPT_GLPK_INC_DIR=${PREFIX}/include
 export CVXOPT_DSDP_LIB_DIR=${PREFIX}/lib
 export CVXOPT_DSDP_INC_DIR=${PREFIX}/include/dsdp
 
-if [[ ${NOMKL} == 1 ]]; then
-  curl -SLO http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.5.5.tar.gz
-  tar -xf SuiteSparse-4.5.5.tar.gz
-  export CVXOPT_SUITESPARSE_SRC_DIR=${PWD}/SuiteSparse
-else
-  export CVXOPT_BLAS_LIB=openblas
-  export CVXOPT_LAPACK_LIB=openblas
-  export CVXOPT_SUITESPARSE_LIB_DIR=${PREFIX}/lib
-  export CVXOPT_SUITESPARSE_INC_DIR=${PREFIX}/include
-fi
+curl -SLO http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.5.5.tar.gz
+tar -xf SuiteSparse-4.5.5.tar.gz
+export CVXOPT_SUITESPARSE_SRC_DIR=${PWD}/SuiteSparse
 
 if [ `uname` == Linux ]
 then

--- a/cvxopt/meta.yaml
+++ b/cvxopt/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 source:
   git_url: https://github.com/cvxopt/cvxopt
-  git_ref: {{ version }}
+  git_rev: {{ version }}
   patches:
     - 0001-MKL-and-MKL-with-GCC-on-Windows-support.patch
     - 0002-use-same-macro-as-in-cholmod_internal.h.patch
@@ -27,7 +27,7 @@ requirements:
   build:
     - python
     - {{p}}git
-    - mkl-devel 2017.0.1      [not nomkl]
+    - mkl-devel		      [not nomkl]
     - libpython               [win]
     - posix                   [win]
     - {{n}}openblas           [nomkl]
@@ -39,7 +39,7 @@ requirements:
     - {{n}}toolchain          [win]
   run:
     - python
-    - mkl 2017.0.1            [not nomkl]
+    - mkl	              [not nomkl]
     - {{n}}openblas           [nomkl]
     - {{n}}suitesparse        [nomkl]
     - {{n}}gsl

--- a/dsdp/build.sh
+++ b/dsdp/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sed -i 's|-llapack||g' make.include
+sed -i "s|-lblas|-L${PREFIX}/lib -lmkl_rt|g" make.include
+sed -i 's|-lg2c||g' make.include
+make DSDPROOT="${PWD}" DSDPCFLAGS="-fPIC" dsdpapi
+
+install -d ${PREFIX}/{lib,include/dsdp}
+install -Dm755 bin/dsdp5 ${PREFIX}/bin/dsdp5
+install -Dm644 lib/* ${PREFIX}/lib/
+install -Dm644 include/*.h ${PREFIX}/include/dsdp/
+install -Dm644 dsdp-license ${PREFIX}/share/licenses/$pkgname/dsdp-license

--- a/dsdp/meta.yaml
+++ b/dsdp/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: dsdp
+  version: 5.8
+
+source:
+  fn: DSDP5.8.tar.gz
+  url: http://www.mcs.anl.gov/hs/software/DSDP/DSDP5.8.tar.gz
+
+build:
+
+requirements:
+  build:
+  - openblas-devel	[linux and nomkl]
+  - mkl-devel		[linux and not nomkl]
+  - libgfortran 	[linux]
+
+about:
+  home: http://www.mcs.anl.gov/hs/software/DSDP
+  license: Other
+  license_file: dsdp-license
+  summary: Software for Semidefinite Programming
+  description:


### PR DESCRIPTION
This is a first attempt at building `cvxopt` (as well as its prerequisite `dsdp`) on Linux64. Some work is needed to generalize the process to other platforms.