### PR TITLE
Updated zeromq to version 4.2.*

### DIFF
--- a/r-packages/r-pbdzmq/meta.yaml
+++ b/r-packages/r-pbdzmq/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - r-base
     - r-r6
     - pkg-config           # [not win]
-    - zeromq 4.1.*         # [not win]
+    - zeromq 4.2.*         # [not win]
     - posix                # [win]
     - {{native}}toolchain  # [win]
     - gcc                  # [not win]
@@ -47,7 +47,7 @@ requirements:
     - r-r6
     - {{native}}gcc-libs   # [win]
     - libgcc               # [not win]
-    - zeromq 4.1.*         # [not win]
+    - zeromq 4.2.*         # [not win]
 
 test:
   commands:


### PR DESCRIPTION
Latest version for https://anaconda.org/anaconda/zeromq is 4.2.3, pinning dependency to older version is causing issues in using latest  version of pyzmq https://github.com/zeromq/pyzmq/tree/v17.0.0 which need latest version of zeromq.
We are unable to use it from within our Jupyter environment.
Steps to reproduce problem:
conda install notebook
conda install r-essentials
The following packages will be DOWNGRADED:
    pyzmq:            17.0.0-py36_3     conda-forge --> 16.0.2-py36_0 defaults   
    zeromq:           4.2.3-2           conda-forge --> 4.1.5-0       conda-forge
This downgrading of zeromq leads to downgrading of pyzmq and produces an error with latest version of Tornado which is 5.0.1